### PR TITLE
Switch Inotify to irmin-watcher

### DIFF
--- a/compiler/src/bin/dune
+++ b/compiler/src/bin/dune
@@ -46,4 +46,4 @@
  (name serve)
  (virtual_modules serve)
  (modules serve)
- (libraries fpath slipshow))
+ (libraries fpath slipshow lwt))

--- a/compiler/src/bin/native/dune
+++ b/compiler/src/bin/native/dune
@@ -4,12 +4,6 @@
  (implements serve)
  (preprocess
   (pps ppx_blob))
- (preprocessor_deps client/client.bc.js)
- (libraries
-  slipshow
-  fpath
-  lwt
-  inotify.lwt
-  dream
-  ; bos
-  ))
+ (preprocessor_deps
+  (file client/client.bc.js))
+ (libraries slipshow fpath lwt irmin-watcher dream))

--- a/dune-project
+++ b/dune-project
@@ -29,7 +29,7 @@
    base64
    bos
    lwt
-   inotify
+   irmin-watcher
    js_of_ocaml-compiler
    js_of_ocaml-lwt
    magic-mime

--- a/slipshow.opam
+++ b/slipshow.opam
@@ -17,7 +17,7 @@ depends: [
   "base64"
   "bos"
   "lwt"
-  "inotify"
+  "irmin-watcher"
   "js_of_ocaml-compiler"
   "js_of_ocaml-lwt"
   "magic-mime"


### PR DESCRIPTION
Thanks for _slips_ @panglesd ! 

Irmin-watcher is a portable, filesystem notification library. On linux it uses inotify and on macOS it uses fsevents. It has a portable, if slow, polling mode too.

This makes slipshow installable on macOS \o/

(( Sorry about all of the formatting that's been sucked into this PR :S -- feel free to cherry pick just the meaninful changes ))