### PR TITLE
Fix act on multiple elements

### DIFF
--- a/src/engine/undoable/undoable.ml
+++ b/src/engine/undoable/undoable.ml
@@ -19,3 +19,14 @@ module Syntax = struct
 end
 
 module Browser = Browser_
+
+module List = struct
+  open Syntax
+
+  let iter f l =
+    List.fold_left
+      (fun acc x ->
+        let> () = acc in
+        f x)
+      (return ()) l
+end

--- a/src/engine/undoable/undoable.mli
+++ b/src/engine/undoable/undoable.mli
@@ -10,3 +10,7 @@ module Syntax : sig
 end
 
 module Browser = Browser_
+
+module List : sig
+  val iter : ('a -> unit t) -> 'a list -> unit t
+end

--- a/test/engine/basic.t/new_engine.md
+++ b/test/engine/basic.t/new_engine.md
@@ -1,5 +1,16 @@
 Salut !
 
+{#a .unstatic}
+a
+
+{#b .unstatic}
+b
+
+{#c .unstatic}
+c
+
+{pause static-at-unpause="a b c"}
+
 {pause up}
 One
 


### PR DESCRIPTION
On some actions, separating with space allows to give several ids of elements to act on:
```
{pause unstatic-at-unpause="id1 id2 id3"}
```
This was lost in the OCaml rewriting. This brings it back!

Thanks @balat for the report!