### PR TITLE
Add commonmark output

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,3 +85,4 @@ TODO
 
 Slipshow vendors a few modified dependencies. Currently it uses
 [git-vendor](https://github.com/brettlangdon/git-vendor).
+

--- a/src/compiler/bin/compile.ml
+++ b/src/compiler/bin/compile.ml
@@ -57,12 +57,7 @@ let compile ~markdown_mode ~math_link ~slip_css_link ~slipshow_js_link ~input
   let slipshow_js_link = Option.map to_asset slipshow_js_link in
   let markdown_compile () =
     let+ content = Io.read input in
-    let md =
-      let md =
-        Cmarkit.Doc.of_string ~heading_auto_ids:true ~strict:false content
-      in
-      Cmarkit_commonmark.of_doc ~include_attributes:false md
-    in
+    let md = Slipshow.convert_to_md content in
     match output with
     | `Stdout ->
         print_string md;

--- a/src/compiler/bin/compile.mli
+++ b/src/compiler/bin/compile.mli
@@ -1,4 +1,5 @@
 val compile :
+  markdown_mode:bool ->
   math_link:string option ->
   slip_css_link:string option ->
   slipshow_js_link:string option ->

--- a/src/compiler/lib/mappings.ml
+++ b/src/compiler/lib/mappings.ml
@@ -65,3 +65,23 @@ let of_cmarkit resolve_images =
     | x -> Some x
   in
   Ast.Mapper.make ~block ~inline ~attrs ()
+
+let to_cmarkit =
+  let block m = function
+    | Ast.Div ((bq, _), meta) ->
+        let b =
+          match Mapper.map_block m bq with None -> Block.empty | Some b -> b
+        in
+        Mapper.ret (Block.Blocks ([ b ], meta))
+    | Ast.SlipScript _ -> Mapper.delete
+    | _ -> Mapper.default
+  in
+  let inline _i = function _ -> Mapper.default in
+  let attrs = function
+    | `Kv (("up", m), v) -> Some (`Kv (("up-at-unpause", m), v))
+    | `Kv (("center", m), v) -> Some (`Kv (("center-at-unpause", m), v))
+    | `Kv (("down", m), v) -> Some (`Kv (("down-at-unpause", m), v))
+    | `Kv (("exec", m), v) -> Some (`Kv (("exec-at-unpause", m), v))
+    | x -> Some x
+  in
+  Ast.Mapper.make ~block ~inline ~attrs ()

--- a/src/compiler/lib/slipshow.ml
+++ b/src/compiler/lib/slipshow.ml
@@ -92,6 +92,13 @@ let string_to_delayed s =
   let s = s |> Base64.decode |> Result.get_ok in
   Marshal.from_string s 0
 
+let convert_to_md content =
+  let md = Cmarkit.Doc.of_string ~heading_auto_ids:true ~strict:false content in
+  let resolve_images = fun x -> Remote x in
+  let sd = Cmarkit.Mapper.map_doc (Mappings.of_cmarkit resolve_images) md in
+  let sd = Cmarkit.Mapper.map_doc Mappings.to_cmarkit sd in
+  Cmarkit_commonmark.of_doc ~include_attributes:false sd
+
 let delayed ?math_link ?slip_css_link ?slipshow_js_link
     ?(resolve_images = fun x -> Remote x) s =
   let md = Cmarkit.Doc.of_string ~heading_auto_ids:true ~strict:false s in

--- a/src/compiler/lib/slipshow.mli
+++ b/src/compiler/lib/slipshow.mli
@@ -29,3 +29,5 @@ val convert :
   ?resolve_images:(string -> asset) ->
   string ->
   string
+
+val convert_to_md : string -> string

--- a/test/compiler/dune
+++ b/test/compiler/dune
@@ -2,5 +2,4 @@
  (name slipshow))
 
 (cram
- (enabled_if false)
  (deps %{bin:slipshow}))

--- a/test/compiler/simple.t/run.t
+++ b/test/compiler/simple.t/run.t
@@ -4,14 +4,14 @@ We can compile the file using the slip_of_mark binary
 
   $ cat file.html | grep "<body>" -A 10
     <body>
-  
-    <!-- This is the presentation -->
-      <slip-slipshow>
-        <slip-slip immediate-enter>
-          <slip-body>
-            <h1 id="a-title"><a class="anchor" aria-hidden="true" href="#a-title"></a><span>A title</span></h1>
+      <div id="slipshow-content">
+        <svg id="slipshow-drawing" style="overflow:visible; position: absolute; z-index:1000"></svg>
+        <div class="slip-rescaler">
+          <div class="slip">
+            <div class="slip-body">
+              <h1 id="a-title"><a class="anchor" aria-hidden="true" href="#a-title"></a><span>A title</span></h1>
   <div pause></div>
-  <p><span>A word </span><span id="id" emph-at-unpause step><span>and</span></span><span> some other words.</span></p>
+  <p><span>A word </span><span id="id" step emph-at-unpause>and</span><span> some other words.</span></p>
   <div pause></div>
   <h2 id="subtitle"><a class="anchor" aria-hidden="true" href="#subtitle"></a><span>subtitle</span></h2>
 
@@ -41,16 +41,16 @@ If we do not pass an input file, it gets its value from stdin
 
   $ cat file.html | grep "<body>" -A 10
     <body>
-  
-    <!-- This is the presentation -->
-      <slip-slipshow>
-        <slip-slip immediate-enter>
-          <slip-body>
-            <h1 id="title"><a class="anchor" aria-hidden="true" href="#title"></a><span>Title</span></h1>
+      <div id="slipshow-content">
+        <svg id="slipshow-drawing" style="overflow:visible; position: absolute; z-index:1000"></svg>
+        <div class="slip-rescaler">
+          <div class="slip">
+            <div class="slip-body">
+              <h1 id="title"><a class="anchor" aria-hidden="true" href="#title"></a><span>Title</span></h1>
   <p><span>Paragraph</span></p>
   
-          </slip-body>
-        </slip-slip>
+            </div>
+          </div>
 
 If we give neither the input nor the output, stdin and stdout are used:
 
@@ -100,4 +100,4 @@ Images
 
   $ slipshow file_with_image.md
   $ cat file_with_image.html | grep image | grep base64
-            <p><span>A paragraph with an </span><img src="data:;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAIAAAACUFjqAAABg2lDQ1BJQ0MgcHJvZmlsZQAAKJF9kT1Iw0AcxV9bpaIVB4OIOGSoTnZREcdahSJUCLVCqw4ml35Bk4YkxcVRcC04+LFYdXBx1tXBVRAEP0BcXZwUXaTE/yWFFjEeHPfj3b3H3Tsg2KgwzeqKA5pum+lkQszmVsXwK/ogIIIhCDKzjDlJSsF3fN0jwNe7GM/yP/fn6FfzFgMCInGcGaZNvEE8s2kbnPeJBVaSVeJz4gmTLkj8yHXF4zfORZeDPFMwM+l5YoFYLHaw0sGsZGrE08RRVdMpP5j1WOW8xVmr1FjrnvyFkby+ssx1mqNIYhFLkCBCQQ1lVGAjRqtOioU07Sd8/COuXyKXQq4yGDkWUIUG2fWD/8Hvbq3C1KSXFEkA3S+O8zEGhHeBZt1xvo8dp3kChJ6BK73trzaA2U/S620tegQMbAMX121N2QMud4DhJ0M2ZVcK0QwWCsD7GX1TDhi8BXrXvN5a+zh9ADLUVeoGODgExouUve7z7p7O3v490+rvB2/RcqXOpP/kAAAACXBIWXMAAC4jAAAuIwF4pT92AAAAB3RJTUUH5wsUDBghqFYBIAAAABl0RVh0Q29tbWVudABDcmVhdGVkIHdpdGggR0lNUFeBDhcAAACeSURBVBjTbY4xCoQwFEQny1aWCVFPkEKTK4SAeATv5wE8gjew+wpewV/aB9xC1Cz4qhkeDIPjYhzHruuGYTgScCciUkp571P9wYVzLsYopUTCd55nAHmen31dV2YuigIAM6OqKmPM6YQQAO4KQEzTtO87AGttWZZZlvV9T0QhhKZpnmvbthlj6rp+v/bKo5dlYea2bf98Oq61JqJ0/AfIKIeErZAqOwAAAABJRU5ErkJggg==" alt="image" ></p>
+              <p><span>A paragraph with an </span><img src="data:;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAIAAAACUFjqAAABg2lDQ1BJQ0MgcHJvZmlsZQAAKJF9kT1Iw0AcxV9bpaIVB4OIOGSoTnZREcdahSJUCLVCqw4ml35Bk4YkxcVRcC04+LFYdXBx1tXBVRAEP0BcXZwUXaTE/yWFFjEeHPfj3b3H3Tsg2KgwzeqKA5pum+lkQszmVsXwK/ogIIIhCDKzjDlJSsF3fN0jwNe7GM/yP/fn6FfzFgMCInGcGaZNvEE8s2kbnPeJBVaSVeJz4gmTLkj8yHXF4zfORZeDPFMwM+l5YoFYLHaw0sGsZGrE08RRVdMpP5j1WOW8xVmr1FjrnvyFkby+ssx1mqNIYhFLkCBCQQ1lVGAjRqtOioU07Sd8/COuXyKXQq4yGDkWUIUG2fWD/8Hvbq3C1KSXFEkA3S+O8zEGhHeBZt1xvo8dp3kChJ6BK73trzaA2U/S620tegQMbAMX121N2QMud4DhJ0M2ZVcK0QwWCsD7GX1TDhi8BXrXvN5a+zh9ADLUVeoGODgExouUve7z7p7O3v490+rvB2/RcqXOpP/kAAAACXBIWXMAAC4jAAAuIwF4pT92AAAAB3RJTUUH5wsUDBghqFYBIAAAABl0RVh0Q29tbWVudABDcmVhdGVkIHdpdGggR0lNUFeBDhcAAACeSURBVBjTbY4xCoQwFEQny1aWCVFPkEKTK4SAeATv5wE8gjew+wpewV/aB9xC1Cz4qhkeDIPjYhzHruuGYTgScCciUkp571P9wYVzLsYopUTCd55nAHmen31dV2YuigIAM6OqKmPM6YQQAO4KQEzTtO87AGttWZZZlvV9T0QhhKZpnmvbthlj6rp+v/bKo5dlYea2bf98Oq61JqJ0/AfIKIeErZAqOwAAAABJRU5ErkJggg==" alt="image" ></p>

--- a/test/compiler/to_commonmark.t/file.md
+++ b/test/compiler/to_commonmark.t/file.md
@@ -1,0 +1,22 @@
+# A title
+
+{pause}
+
+A word and{#id step emph-at-unpause} some other words.
+
+{pause}
+
+## subtitle
+
+{pause}
+> Blibli.
+> Some other content
+
+{pause blockquote}
+> Blibli.
+> Some other content
+
+
+[emph]: {style="color: red"}
+
+And {pause} [standalone][emph] inlines2

--- a/test/compiler/to_commonmark.t/run.t
+++ b/test/compiler/to_commonmark.t/run.t
@@ -1,0 +1,23 @@
+We can compile the file using the slip_of_mark binary
+
+  $ slipshow --markdown-output file.md
+
+  $ cat file.noattrs.md
+  # A title
+  
+  
+  A word and some other words.
+  
+  
+  ## subtitle
+  
+  Blibli.
+  Some other content
+  
+  > Blibli.
+  > Some other content
+  
+  
+  <!-- Unknown Cmarkit block -->
+  
+  And  [standalone][emph] inlines2

--- a/test/compiler/to_commonmark.t/run.t
+++ b/test/compiler/to_commonmark.t/run.t
@@ -18,6 +18,5 @@ We can compile the file using the slip_of_mark binary
   > Some other content
   
   
-  <!-- Unknown Cmarkit block -->
   
   And  [standalone][emph] inlines2

--- a/vendor/github.com/panglesd/cmarkit/B0.ml
+++ b/vendor/github.com/panglesd/cmarkit/B0.ml
@@ -133,7 +133,8 @@ let expect_cmarkit_renders ctx =
   let renderers = (* command, output suffix *)
     [ Cmd.(arg "html" % "-c" % "--unsafe"), ".html";
       Cmd.(arg "latex"), ".latex";
-      Cmd.(arg "commonmark"), ".trip.md";
+      Cmd.(arg "commonmark"), ".strip-attributes.md";
+      Cmd.(arg "commonmark" % "--include-attributes"), ".trip.md";
       Cmd.(arg "locs"), ".locs";
       Cmd.(arg "locs" % "--no-layout"), ".nolayout.locs"; ]
   in
@@ -148,7 +149,7 @@ let expect_cmarkit_renders ctx =
   in
   let test_files =
     let base_files = B0_expect.base_files ctx ~rel:true ~recurse:false in
-    let input f = Fpath.has_ext ".md" f && not (Fpath.has_ext ".trip.md" f) in
+    let input f = Fpath.has_ext ".md" f && not (Fpath.has_ext ".trip.md" f) && not (Fpath.has_ext ".strip-attributes.md" f) in
     List.filter input base_files
   in
   List.iter (test_file ctx cmarkit) test_files

--- a/vendor/github.com/panglesd/cmarkit/src/cmarkit_commonmark.ml
+++ b/vendor/github.com/panglesd/cmarkit/src/cmarkit_commonmark.ml
@@ -13,14 +13,24 @@ type indent =
 | `Fn of int * Label.t ]
 
 type state =
-  { nl : string; (* newline to output. *)
+  { include_attributes : bool;
+    nl : string; (* newline to output. *)
     mutable sot : bool; (* start of text *)
     mutable indents : indent list; (* indentation stack. *) }
 
 let state : state C.State.t = C.State.make ()
 let get_state c = C.State.get c state
-let init_context c d =
-  C.State.set c state (Some { nl = Cmarkit.Doc.nl d; sot = true; indents = [] })
+let init_context ~include_attributes c d =
+  C.State.set c state
+    (Some
+       { include_attributes ;
+         nl = Cmarkit.Doc.nl d;
+         sot = true;
+         indents = [] })
+
+let include_attributes c =
+  let state = get_state c in
+  state.include_attributes
 
 (* Escaping *)
 
@@ -169,7 +179,8 @@ let tight_block_lines c = function
 
 (* Inline rendering *)
 
-let attributes c attrs =
+let attributes ?(inline = false) c attrs =
+  if not (include_attributes c) then () else begin
   let kv_attrs =
     let kv_attrs = Cmarkit.Attributes.kv_attributes attrs in
     List.map
@@ -191,8 +202,8 @@ let attributes c attrs =
   let attrs = id @ class' @ kv_attrs in
   if attrs = [] then () else
     begin
-      newline c;
-      indent c;
+      if not inline then
+        (newline c; indent c);
       let attrs =
         List.map
           (function
@@ -207,8 +218,9 @@ let attributes c attrs =
       C.string c s;
       C.string c "}"
     end
+  end
 
-let autolink c a =
+let autolink c a _TODO =
   C.byte c '<'; C.string c (fst (Inline.Autolink.link a)); C.byte c '>'
 
 let break c b =
@@ -220,20 +232,23 @@ let break c b =
   in
   C.string c before; newline c; indent c; C.string c after
 
-let code_span c cs =
+let code_span c cs attrs =
   nchars c (Inline.Code_span.backtick_count cs) '`';
   tight_block_lines c (Inline.Code_span.code_layout cs);
-  nchars c (Inline.Code_span.backtick_count cs) '`'
+  nchars c (Inline.Code_span.backtick_count cs) '`';
+  attributes ~inline:true c attrs
 
-let emphasis c e =
+let emphasis c e attrs =
   let delim = Inline.Emphasis.delim e and i = Inline.Emphasis.inline e in
   let delim = if not (delim = '*' || delim = '_') then '*' else delim in
-  C.byte c delim; C.inline c i; C.byte c delim
+  C.byte c delim; C.inline c i; C.byte c delim;
+  attributes ~inline:true c attrs
 
-let strong_emphasis c e =
+let strong_emphasis c e attrs =
   let delim = Inline.Emphasis.delim e and i = Inline.Emphasis.inline e in
   let delim = if not (delim = '*' || delim = '_') then '*' else delim in
-  C.byte c delim;  C.byte c delim; C.inline c i; C.byte c delim; C.byte c delim
+  C.byte c delim;  C.byte c delim; C.inline c i; C.byte c delim; C.byte c delim;
+  attributes ~inline:true c attrs
 
 let link_title c open_delim title = match title with
 | None -> ()
@@ -264,7 +279,7 @@ let link_definition c ld =
   link_title c layout.title_open_delim (Link_definition.title ld);
   block_lines c layout.after_title
 
-let link c l = match Inline.Link.reference l with
+let link c l attrs = (match Inline.Link.reference l with
 | `Inline ((ld, _), _) ->
     C.byte c '['; C.inline c (Inline.Link.text l); C.byte c ']';
     C.byte c '('; link_definition c ld; C.byte c ')'
@@ -275,42 +290,49 @@ let link c l = match Inline.Link.reference l with
     C.string c "[]"
 | `Ref (`Full, label, _)  ->
     C.byte c '['; C.inline c (Inline.Link.text l); C.byte c ']';
-    C.byte c '['; link_label_lines c (Label.text label); C.byte c ']'
+    C.byte c '['; link_label_lines c (Label.text label); C.byte c ']');
+  attributes ~inline:true c attrs
 
 let attrs_span c span =
   let content = Inline.Attributes_span.content span
   and (attrs, _) = Inline.Attributes_span.attrs span in
-  C.byte c '['; C.inline c content; C.byte c ']';
-  attributes c attrs
+  if not (include_attributes c) then C.inline c content else begin
+    C.byte c '['; C.inline c content; C.byte c ']';
+    attributes ~inline:true c attrs
+  end
 
 let inlines c is = List.iter (C.inline c) is
-let image c l = C.byte c '!'; link c l
+let image c l attrs = C.byte c '!'; link c l attrs
 let raw_html c h = tight_block_lines c h
-let text c t = escaped_text c t
+let text c t attrs =
+  escaped_text c t;
+  attributes ~inline:true c attrs
 
-let strikethrough c s =
+let strikethrough c s attrs =
   let i = Inline.Strikethrough.inline s in
-  C.string c "~~"; C.inline c i; C.string c "~~"
+  C.string c "~~"; C.inline c i; C.string c "~~";
+  attributes ~inline:true c attrs
 
-let math_span c ms =
+let math_span c ms attrs =
   let sep = if Inline.Math_span.display ms then "$$" else "$" in
   C.string c sep;
   tight_block_lines c (Inline.Math_span.tex_layout ms);
-  C.string c sep
+  C.string c sep;
+  attributes ~inline:true c attrs
 
 let inline c = function
-| Inline.Autolink ((a, _TODO), _) -> autolink c a; true
+| Inline.Autolink ((a, (attrs, _)), _) -> autolink c a attrs; true
 | Inline.Break (b, _) -> break c b; true
-| Inline.Code_span ((cs, _TODO), _) -> code_span c cs; true
-| Inline.Emphasis ((e, _TODO), _) -> emphasis c e; true
-| Inline.Image ((i, _TODO), _) -> image c i; true
+| Inline.Code_span ((cs, (attrs, _)), _) -> code_span c cs attrs; true
+| Inline.Emphasis ((e, (attrs, _)), _) -> emphasis c e attrs; true
+| Inline.Image ((i, (attrs, _)), _) -> image c i attrs; true
 | Inline.Inlines (is, _) -> inlines c is; true
-| Inline.Link ((l, _TODO), _) -> link c l; true
+| Inline.Link ((l, (attrs, _)), _) -> link c l attrs; true
 | Inline.Raw_html (html, _) -> raw_html c html; true
-| Inline.Strong_emphasis ((e, _TODO), _) -> strong_emphasis c e; true
-| Inline.Text ((t, _TODO), _) -> text c t; true
-| Inline.Ext_strikethrough ((s, _TODO), _) -> strikethrough c s; true
-| Inline.Ext_math_span ((m, _TODO), _) -> math_span c m; true
+| Inline.Strong_emphasis ((e, (attrs, _)), _) -> strong_emphasis c e attrs; true
+| Inline.Text ((t, (attrs, _)), _) -> text c t attrs; true
+| Inline.Ext_strikethrough ((s, (attrs, _)), _) -> strikethrough c s attrs; true
+| Inline.Ext_math_span ((m, (attrs, _)), _) -> math_span c m attrs; true
 | Inline.Ext_attrs (span, _) -> attrs_span c span; true
 | _ -> C.string c "<!-- Unknown Cmarkit inline -->"; true
 
@@ -487,5 +509,8 @@ let doc c d = C.block c (Doc.block d); true
 
 (* Renderer *)
 
-let renderer () = Cmarkit_renderer.make ~init_context ~inline ~block ~doc ()
-let of_doc d = Cmarkit_renderer.doc_to_string (renderer ()) d
+let renderer ?(include_attributes = false) () =
+  let init_context = init_context ~include_attributes in
+  Cmarkit_renderer.make ~init_context ~inline ~block ~doc ()
+let of_doc ?(include_attributes = false) d =
+  Cmarkit_renderer.doc_to_string (renderer ~include_attributes ()) d

--- a/vendor/github.com/panglesd/cmarkit/src/cmarkit_commonmark.ml
+++ b/vendor/github.com/panglesd/cmarkit/src/cmarkit_commonmark.ml
@@ -485,6 +485,14 @@ let footnote c fn attrs =
 
 let standalone_attributes c attrs = attributes c attrs
 
+let attribute_def c ad attrs =
+  attributes c attrs;
+  push_indent c (`Fn (Block.Attribute_definition.indent ad,
+                      Block.Attribute_definition.label ad));
+  let (attrs, _) = Block.Attribute_definition.attrs ad in
+  standalone_attributes c attrs;
+  pop_indent c
+
 let block c = function
 | Block.Blank_line (l, _) -> blank_line c l; true
 | Block.Block_quote ((b, (attrs, _)), _) -> block_quote c b attrs; true
@@ -501,6 +509,7 @@ let block c = function
 | Block.Ext_table ((t, (attrs, _)), _) -> table c t attrs; true
 | Block.Ext_footnote_definition ((t, (attrs, _)), _) -> footnote c t attrs; true
 | Block.Ext_standalone_attributes (attrs, _) -> standalone_attributes c attrs; true
+| Block.Ext_attribute_definition ((attr_def, (attrs, _)), _) -> attribute_def c attr_def attrs; true
 | _ -> newline c; indent c; C.string c "<!-- Unknown Cmarkit block -->"; true
 
 (* Document rendering *)

--- a/vendor/github.com/panglesd/cmarkit/src/cmarkit_commonmark.mli
+++ b/vendor/github.com/panglesd/cmarkit/src/cmarkit_commonmark.mli
@@ -17,13 +17,13 @@
 
 (** {1:rendering Rendering} *)
 
-val of_doc : Cmarkit.Doc.t -> string
+val of_doc : ?include_attributes:bool -> Cmarkit.Doc.t -> string
 (** [of_doc d] is a CommonMark document for [d]. See {!val-renderer} for
     more details. *)
 
 (** {1:renderer Renderer} *)
 
-val renderer : unit -> Cmarkit_renderer.t
+val renderer : ?include_attributes:bool -> unit -> Cmarkit_renderer.t
 (** [renderer ()] is the default CommonMark renderer. This renders
     the strict CommonMark abstract syntax tree and the supported
     Cmarkit {{!Cmarkit.extensions}extensions}.

--- a/vendor/github.com/panglesd/cmarkit/test/examples.ml
+++ b/vendor/github.com/panglesd/cmarkit/test/examples.ml
@@ -15,7 +15,12 @@ fun ~strict md ->
 let cmark_to_commonmark : strict:bool -> string -> string =
 fun ~strict md ->
   let doc = Cmarkit.Doc.of_string ~layout:true ~strict md in
-  Cmarkit_commonmark.of_doc doc
+  Cmarkit_commonmark.of_doc ~include_attributes:false doc
+
+let cmark_to_commonmark_attrs : strict:bool -> string -> string =
+fun ~strict md ->
+  let doc = Cmarkit.Doc.of_string ~layout:true ~strict md in
+  Cmarkit_commonmark.of_doc ~include_attributes:true doc
 
 (* Cmarkit_renderer *)
 

--- a/vendor/github.com/panglesd/cmarkit/test/expect/basic.exts.html
+++ b/vendor/github.com/panglesd/cmarkit/test/expect/basic.exts.html
@@ -476,7 +476,8 @@ Paragraphy</p>
 <p>Attributes can be nested: <a href="example.com">link <span attrs>with</span></a>, <span attrs>attrs <a href="example.com">with
 link</a></span>, <span attrs2>attrs <span attrs1>within</span></span>.</p>
 <p>Attributes can be attached without squares, for instance <span id="idee">this</span> has an
-id. This <code id="too">codeblock</code>! This <img src="as" id="well" alt="image" >. <a href="work" id="the" class="same">Links</a>.</p>
+id. This <code id="too">codeblock</code>! This <img src="as" id="well" alt="image" >. <a href="work" id="the" class="same">Links</a>. <strong and>Emphasis</strong> and <em and>italic1</em> <em too>italic2</em>!</p>
+<p>Testing <del text>strikethrough</del>.</p>
 <h2 id="id"><a class="anchor" aria-hidden="true" href="#id"></a>Title with an id</h2>
 <h1 id="id"><a class="anchor" aria-hidden="true" href="#id"></a>Title with an id</h1>
 <h3>Attributes definition</h3>

--- a/vendor/github.com/panglesd/cmarkit/test/expect/basic.exts.latex
+++ b/vendor/github.com/panglesd/cmarkit/test/expect/basic.exts.latex
@@ -450,7 +450,9 @@ Attributes can be nested: \href{example.com}{link % Attributes omitted
 .
 
 Attributes can be attached without squares, for instance this has an
-id. This \texttt{codeblock}! This \protect\includegraphics{as}. \href{work}{Links}.
+id. This \texttt{codeblock}! This \protect\includegraphics{as}. \href{work}{Links}. \textbf{Emphasis} and \emph{italic1} \emph{italic2}!
+
+Testing \sout{strikethrough}.
 % Attributes cannot be rendered in latex
 
 \subsection{Title with an id}

--- a/vendor/github.com/panglesd/cmarkit/test/expect/basic.exts.locs
+++ b/vendor/github.com/panglesd/cmarkit/test/expect/basic.exts.locs
@@ -1,5 +1,5 @@
 Blocks:
-File "basic.exts.md", lines 1-278
+File "basic.exts.md", lines 1-282
   Heading, level 1:
   File "basic.exts.md", line 1, characters 0-12
     Text:
@@ -1733,5 +1733,15 @@ Unknown Cmarkit block
     File "basic.exts.md", line 276, characters 23-41
   Blank line:
   File "basic.exts.md", line 277
+  Footnote definition:
+  File "basic.exts.md", lines 279-280, characters 0-7
+    Label:
+    File "basic.exts.md", line 279, characters 1-15
+    Paragraph:
+    File "basic.exts.md", line 280, characters 2-7
+      Text:
+      File "basic.exts.md", line 280, characters 2-7
   Blank line:
-  File "basic.exts.md", line 278
+  File "basic.exts.md", line 281
+  Blank line:
+  File "basic.exts.md", line 282

--- a/vendor/github.com/panglesd/cmarkit/test/expect/basic.exts.locs
+++ b/vendor/github.com/panglesd/cmarkit/test/expect/basic.exts.locs
@@ -1,5 +1,5 @@
 Blocks:
-File "basic.exts.md", lines 1-276
+File "basic.exts.md", lines 1-278
   Heading, level 1:
   File "basic.exts.md", line 1, characters 0-12
     Text:
@@ -1515,9 +1515,9 @@ File "basic.exts.md", lines 1-276
   Blank line:
   File "basic.exts.md", line 243
   Paragraph:
-  File "basic.exts.md", lines 244-245, characters 0-80
+  File "basic.exts.md", lines 244-245, characters 0-133
     Inlines:
-    File "basic.exts.md", lines 244-245, characters 0-80
+    File "basic.exts.md", lines 244-245, characters 0-133
       Text:
       File "basic.exts.md", line 244, characters 0-57
       Text:
@@ -1557,149 +1557,181 @@ File "basic.exts.md", lines 1-276
         Destination:
         File "basic.exts.md", line 245, characters 62-66
       Text:
-      File "basic.exts.md", line 245, characters 79-80
+      File "basic.exts.md", line 245, characters 79-81
+      Strong emphasis:
+      File "basic.exts.md", line 245, characters 81-93
+        Text:
+        File "basic.exts.md", line 245, characters 83-91
+      Text:
+      File "basic.exts.md", line 245, characters 98-103
+      Emphasis:
+      File "basic.exts.md", line 245, characters 103-112
+        Text:
+        File "basic.exts.md", line 245, characters 104-111
+      Text:
+      File "basic.exts.md", line 245, characters 117-118
+      Emphasis:
+      File "basic.exts.md", line 245, characters 118-127
+        Text:
+        File "basic.exts.md", line 245, characters 119-126
+      Text:
+      File "basic.exts.md", line 245, characters 132-133
   Blank line:
   File "basic.exts.md", line 246
+  Paragraph:
+  File "basic.exts.md", line 247, characters 0-32
+    Inlines:
+    File "basic.exts.md", line 247, characters 0-32
+      Text:
+      File "basic.exts.md", line 247, characters 0-8
+      Strikethrough:
+      File "basic.exts.md", line 247, characters 8-25
+        Text:
+        File "basic.exts.md", line 247, characters 10-23
+      Text:
+      File "basic.exts.md", line 247, characters 31-32
+  Blank line:
+  File "basic.exts.md", line 248
   Heading, level 2:
-  File "basic.exts.md", line 248, characters 0-19
+  File "basic.exts.md", line 250, characters 0-19
     Text:
-    File "basic.exts.md", line 248, characters 3-19
+    File "basic.exts.md", line 250, characters 3-19
   Blank line:
-  File "basic.exts.md", line 249
+  File "basic.exts.md", line 251
   Heading, level 1:
-  File "basic.exts.md", lines 251-252, characters 0-16
+  File "basic.exts.md", lines 253-254, characters 0-16
     Text:
-    File "basic.exts.md", line 251, characters 0-16
+    File "basic.exts.md", line 253, characters 0-16
     Setext underline:
-    File "basic.exts.md", line 252, characters 0-16
+    File "basic.exts.md", line 254, characters 0-16
   Blank line:
-  File "basic.exts.md", line 253
-  Blank line:
-  File "basic.exts.md", line 254
-  Heading, level 3:
-  File "basic.exts.md", line 255, characters 0-25
-    Text:
-    File "basic.exts.md", line 255, characters 4-25
+  File "basic.exts.md", line 255
   Blank line:
   File "basic.exts.md", line 256
-  Paragraph:
-  File "basic.exts.md", line 257, characters 0-97
-    Inlines:
-    File "basic.exts.md", line 257, characters 0-97
-      Text:
-      File "basic.exts.md", line 257, characters 0-15
-      Link:
-      File "basic.exts.md", line 257, characters 15-30
-        Text:
-        File "basic.exts.md", line 257, characters 16-26
-        Label:
-        File "basic.exts.md", line 257, characters 28-29
-        Label definition:
-        File "basic.exts.md", line 260, characters 1-2
-      Text:
-      File "basic.exts.md", line 257, characters 30-45
-      Link:
-      File "basic.exts.md", line 257, characters 45-55
-        Text:
-        File "basic.exts.md", line 257, characters 46-51
-        Label:
-        File "basic.exts.md", line 257, characters 53-54
-        Label definition:
-        File "basic.exts.md", line 260, characters 1-2
-      Text:
-      File "basic.exts.md", line 257, characters 55-56
-      Link:
-      File "basic.exts.md", line 257, characters 56-68
-        Text:
-        File "basic.exts.md", line 257, characters 57-67
-        Label:
-        File "basic.exts.md", line 257, characters 57-67
-        Label definition:
-        File "basic.exts.md", line 259, characters 1-11
-      Text:
-      File "basic.exts.md", line 257, characters 68-71
-      Link:
-      File "basic.exts.md", line 257, characters 71-85
-        Text:
-        File "basic.exts.md", line 257, characters 72-81
-        Label:
-        File "basic.exts.md", line 257, characters 83-84
-        Label definition:
-        File "basic.exts.md", line 260, characters 1-2
-      Text:
-      File "basic.exts.md", line 257, characters 85-97
+  Heading, level 3:
+  File "basic.exts.md", line 257, characters 0-25
+    Text:
+    File "basic.exts.md", line 257, characters 4-25
   Blank line:
   File "basic.exts.md", line 258
-
-
-Unknown Cmarkit block
-
-
-Unknown Cmarkit block
-  Blank line:
-  File "basic.exts.md", line 261
   Paragraph:
-  File "basic.exts.md", line 262, characters 0-55
-    Text:
-    File "basic.exts.md", line 262, characters 0-55
+  File "basic.exts.md", line 259, characters 0-97
+    Inlines:
+    File "basic.exts.md", line 259, characters 0-97
+      Text:
+      File "basic.exts.md", line 259, characters 0-15
+      Link:
+      File "basic.exts.md", line 259, characters 15-30
+        Text:
+        File "basic.exts.md", line 259, characters 16-26
+        Label:
+        File "basic.exts.md", line 259, characters 28-29
+        Label definition:
+        File "basic.exts.md", line 262, characters 1-2
+      Text:
+      File "basic.exts.md", line 259, characters 30-45
+      Link:
+      File "basic.exts.md", line 259, characters 45-55
+        Text:
+        File "basic.exts.md", line 259, characters 46-51
+        Label:
+        File "basic.exts.md", line 259, characters 53-54
+        Label definition:
+        File "basic.exts.md", line 262, characters 1-2
+      Text:
+      File "basic.exts.md", line 259, characters 55-56
+      Link:
+      File "basic.exts.md", line 259, characters 56-68
+        Text:
+        File "basic.exts.md", line 259, characters 57-67
+        Label:
+        File "basic.exts.md", line 259, characters 57-67
+        Label definition:
+        File "basic.exts.md", line 261, characters 1-11
+      Text:
+      File "basic.exts.md", line 259, characters 68-71
+      Link:
+      File "basic.exts.md", line 259, characters 71-85
+        Text:
+        File "basic.exts.md", line 259, characters 72-81
+        Label:
+        File "basic.exts.md", line 259, characters 83-84
+        Label definition:
+        File "basic.exts.md", line 262, characters 1-2
+      Text:
+      File "basic.exts.md", line 259, characters 85-97
+  Blank line:
+  File "basic.exts.md", line 260
+
+
+Unknown Cmarkit block
+
+
+Unknown Cmarkit block
   Blank line:
   File "basic.exts.md", line 263
   Paragraph:
-  File "basic.exts.md", line 264, characters 0-26
-    Inlines:
-    File "basic.exts.md", line 264, characters 0-26
-      Text:
-      File "basic.exts.md", line 264, characters 0-2
-      Link:
-      File "basic.exts.md", line 264, characters 2-24
-        Text:
-        File "basic.exts.md", line 264, characters 3-4
-        Label:
-        File "basic.exts.md", line 264, characters 6-23
-        Label definition:
-        File "basic.exts.md", line 267, characters 1-18
-      Text:
-      File "basic.exts.md", line 264, characters 24-26
+  File "basic.exts.md", line 264, characters 0-55
+    Text:
+    File "basic.exts.md", line 264, characters 0-55
   Blank line:
   File "basic.exts.md", line 265
+  Paragraph:
+  File "basic.exts.md", line 266, characters 0-26
+    Inlines:
+    File "basic.exts.md", line 266, characters 0-26
+      Text:
+      File "basic.exts.md", line 266, characters 0-2
+      Link:
+      File "basic.exts.md", line 266, characters 2-24
+        Text:
+        File "basic.exts.md", line 266, characters 3-4
+        Label:
+        File "basic.exts.md", line 266, characters 6-23
+        Label definition:
+        File "basic.exts.md", line 269, characters 1-18
+      Text:
+      File "basic.exts.md", line 266, characters 24-26
+  Blank line:
+  File "basic.exts.md", line 267
 
 
 Unknown Cmarkit block
   Blank line:
-  File "basic.exts.md", line 268
-  Paragraph:
-  File "basic.exts.md", line 269, characters 0-47
-    Text:
-    File "basic.exts.md", line 269, characters 0-47
-  Blank line:
   File "basic.exts.md", line 270
   Paragraph:
-  File "basic.exts.md", line 271, characters 0-28
-    Inlines:
-    File "basic.exts.md", line 271, characters 0-28
-      Text:
-      File "basic.exts.md", line 271, characters 0-2
-      Link:
-      File "basic.exts.md", line 271, characters 2-26
-        Text:
-        File "basic.exts.md", line 271, characters 3-4
-        Label:
-        File "basic.exts.md", line 271, characters 6-25
-        Label definition:
-        File "basic.exts.md", line 274, characters 1-20
-      Text:
-      File "basic.exts.md", line 271, characters 26-28
+  File "basic.exts.md", line 271, characters 0-47
+    Text:
+    File "basic.exts.md", line 271, characters 0-47
   Blank line:
   File "basic.exts.md", line 272
+  Paragraph:
+  File "basic.exts.md", line 273, characters 0-28
+    Inlines:
+    File "basic.exts.md", line 273, characters 0-28
+      Text:
+      File "basic.exts.md", line 273, characters 0-2
+      Link:
+      File "basic.exts.md", line 273, characters 2-26
+        Text:
+        File "basic.exts.md", line 273, characters 3-4
+        Label:
+        File "basic.exts.md", line 273, characters 6-25
+        Label definition:
+        File "basic.exts.md", line 276, characters 1-20
+      Text:
+      File "basic.exts.md", line 273, characters 26-28
+  Blank line:
+  File "basic.exts.md", line 274
   Link reference definition:
-  File "basic.exts.md", line 274, characters 0-41
+  File "basic.exts.md", line 276, characters 0-41
     Label:
-    File "basic.exts.md", line 274, characters 1-20
+    File "basic.exts.md", line 276, characters 1-20
     Defined label:
-    File "basic.exts.md", line 274, characters 1-20
+    File "basic.exts.md", line 276, characters 1-20
     Destination:
-    File "basic.exts.md", line 274, characters 23-41
+    File "basic.exts.md", line 276, characters 23-41
   Blank line:
-  File "basic.exts.md", line 275
+  File "basic.exts.md", line 277
   Blank line:
-  File "basic.exts.md", line 276
+  File "basic.exts.md", line 278

--- a/vendor/github.com/panglesd/cmarkit/test/expect/basic.exts.md
+++ b/vendor/github.com/panglesd/cmarkit/test/expect/basic.exts.md
@@ -275,3 +275,7 @@ A [b][link-def-with-attrs] c
 {.present}
 [link-def-with-attrs]: http://example.com
 
+{.present}
+[^link-def-with]:{#ID}
+  Hello
+

--- a/vendor/github.com/panglesd/cmarkit/test/expect/basic.exts.md
+++ b/vendor/github.com/panglesd/cmarkit/test/expect/basic.exts.md
@@ -242,7 +242,9 @@ Attributes can be nested: [link [with]{attrs}](example.com), [attrs [with
 link](example.com)]{attrs}, [attrs [within]{attrs1}]{attrs2}.
 
 Attributes can be attached without squares, for instance this{#idee} has an
-id. This `codeblock`{#too}! This ![image](as){#well}. [Links](work){#the .same}.
+id. This `codeblock`{#too}! This ![image](as){#well}. [Links](work){#the .same}. **Emphasis**{and} and *italic1*{and} _italic2_{too}!
+
+Testing ~~strikethrough~~{text}.
 
 {#id}
 ## Title with an id

--- a/vendor/github.com/panglesd/cmarkit/test/expect/basic.exts.nolayout.locs
+++ b/vendor/github.com/panglesd/cmarkit/test/expect/basic.exts.nolayout.locs
@@ -1,5 +1,5 @@
 Blocks:
-File "basic.exts.md", lines 1-278
+File "basic.exts.md", lines 1-282
   Heading, level 1:
   File "basic.exts.md", line 1, characters 0-12
     Text:
@@ -1733,5 +1733,15 @@ Unknown Cmarkit block
     File "basic.exts.md", line 276, characters 23-41
   Blank line:
   File "basic.exts.md", line 277
+  Footnote definition:
+  File "basic.exts.md", lines 279-280, characters 0-7
+    Label:
+    File "basic.exts.md", line 279, characters 1-15
+    Paragraph:
+    File "basic.exts.md", line 280, characters 2-7
+      Text:
+      File "basic.exts.md", line 280, characters 2-7
   Blank line:
-  File "basic.exts.md", line 278
+  File "basic.exts.md", line 281
+  Blank line:
+  File "basic.exts.md", line 282

--- a/vendor/github.com/panglesd/cmarkit/test/expect/basic.exts.nolayout.locs
+++ b/vendor/github.com/panglesd/cmarkit/test/expect/basic.exts.nolayout.locs
@@ -1,5 +1,5 @@
 Blocks:
-File "basic.exts.md", lines 1-276
+File "basic.exts.md", lines 1-278
   Heading, level 1:
   File "basic.exts.md", line 1, characters 0-12
     Text:
@@ -1515,9 +1515,9 @@ File "basic.exts.md", lines 1-276
   Blank line:
   File "basic.exts.md", line 243
   Paragraph:
-  File "basic.exts.md", lines 244-245, characters 0-80
+  File "basic.exts.md", lines 244-245, characters 0-133
     Inlines:
-    File "basic.exts.md", lines 244-245, characters 0-80
+    File "basic.exts.md", lines 244-245, characters 0-133
       Text:
       File "basic.exts.md", line 244, characters 0-57
       Text:
@@ -1557,149 +1557,181 @@ File "basic.exts.md", lines 1-276
         Destination:
         File "basic.exts.md", line 245, characters 62-66
       Text:
-      File "basic.exts.md", line 245, characters 79-80
+      File "basic.exts.md", line 245, characters 79-81
+      Strong emphasis:
+      File "basic.exts.md", line 245, characters 81-93
+        Text:
+        File "basic.exts.md", line 245, characters 83-91
+      Text:
+      File "basic.exts.md", line 245, characters 98-103
+      Emphasis:
+      File "basic.exts.md", line 245, characters 103-112
+        Text:
+        File "basic.exts.md", line 245, characters 104-111
+      Text:
+      File "basic.exts.md", line 245, characters 117-118
+      Emphasis:
+      File "basic.exts.md", line 245, characters 118-127
+        Text:
+        File "basic.exts.md", line 245, characters 119-126
+      Text:
+      File "basic.exts.md", line 245, characters 132-133
   Blank line:
   File "basic.exts.md", line 246
+  Paragraph:
+  File "basic.exts.md", line 247, characters 0-32
+    Inlines:
+    File "basic.exts.md", line 247, characters 0-32
+      Text:
+      File "basic.exts.md", line 247, characters 0-8
+      Strikethrough:
+      File "basic.exts.md", line 247, characters 8-25
+        Text:
+        File "basic.exts.md", line 247, characters 10-23
+      Text:
+      File "basic.exts.md", line 247, characters 31-32
+  Blank line:
+  File "basic.exts.md", line 248
   Heading, level 2:
-  File "basic.exts.md", line 248, characters 0-19
+  File "basic.exts.md", line 250, characters 0-19
     Text:
-    File "basic.exts.md", line 248, characters 3-19
+    File "basic.exts.md", line 250, characters 3-19
   Blank line:
-  File "basic.exts.md", line 249
+  File "basic.exts.md", line 251
   Heading, level 1:
-  File "basic.exts.md", lines 251-252, characters 0-16
+  File "basic.exts.md", lines 253-254, characters 0-16
     Text:
-    File "basic.exts.md", line 251, characters 0-16
+    File "basic.exts.md", line 253, characters 0-16
     Setext underline:
-    File "basic.exts.md", line 252, characters 0-16
+    File "basic.exts.md", line 254, characters 0-16
   Blank line:
-  File "basic.exts.md", line 253
-  Blank line:
-  File "basic.exts.md", line 254
-  Heading, level 3:
-  File "basic.exts.md", line 255, characters 0-25
-    Text:
-    File "basic.exts.md", line 255, characters 4-25
+  File "basic.exts.md", line 255
   Blank line:
   File "basic.exts.md", line 256
-  Paragraph:
-  File "basic.exts.md", line 257, characters 0-97
-    Inlines:
-    File "basic.exts.md", line 257, characters 0-97
-      Text:
-      File "basic.exts.md", line 257, characters 0-15
-      Link:
-      File "basic.exts.md", line 257, characters 15-30
-        Text:
-        File "basic.exts.md", line 257, characters 16-26
-        Label:
-        File "basic.exts.md", line 257, characters 28-29
-        Label definition:
-        File "basic.exts.md", line 260, characters 1-2
-      Text:
-      File "basic.exts.md", line 257, characters 30-45
-      Link:
-      File "basic.exts.md", line 257, characters 45-55
-        Text:
-        File "basic.exts.md", line 257, characters 46-51
-        Label:
-        File "basic.exts.md", line 257, characters 53-54
-        Label definition:
-        File "basic.exts.md", line 260, characters 1-2
-      Text:
-      File "basic.exts.md", line 257, characters 55-56
-      Link:
-      File "basic.exts.md", line 257, characters 56-68
-        Text:
-        File "basic.exts.md", line 257, characters 57-67
-        Label:
-        File "basic.exts.md", line 257, characters 57-67
-        Label definition:
-        File "basic.exts.md", line 259, characters 1-11
-      Text:
-      File "basic.exts.md", line 257, characters 68-71
-      Link:
-      File "basic.exts.md", line 257, characters 71-85
-        Text:
-        File "basic.exts.md", line 257, characters 72-81
-        Label:
-        File "basic.exts.md", line 257, characters 83-84
-        Label definition:
-        File "basic.exts.md", line 260, characters 1-2
-      Text:
-      File "basic.exts.md", line 257, characters 85-97
+  Heading, level 3:
+  File "basic.exts.md", line 257, characters 0-25
+    Text:
+    File "basic.exts.md", line 257, characters 4-25
   Blank line:
   File "basic.exts.md", line 258
-
-
-Unknown Cmarkit block
-
-
-Unknown Cmarkit block
-  Blank line:
-  File "basic.exts.md", line 261
   Paragraph:
-  File "basic.exts.md", line 262, characters 0-55
-    Text:
-    File "basic.exts.md", line 262, characters 0-55
+  File "basic.exts.md", line 259, characters 0-97
+    Inlines:
+    File "basic.exts.md", line 259, characters 0-97
+      Text:
+      File "basic.exts.md", line 259, characters 0-15
+      Link:
+      File "basic.exts.md", line 259, characters 15-30
+        Text:
+        File "basic.exts.md", line 259, characters 16-26
+        Label:
+        File "basic.exts.md", line 259, characters 28-29
+        Label definition:
+        File "basic.exts.md", line 262, characters 1-2
+      Text:
+      File "basic.exts.md", line 259, characters 30-45
+      Link:
+      File "basic.exts.md", line 259, characters 45-55
+        Text:
+        File "basic.exts.md", line 259, characters 46-51
+        Label:
+        File "basic.exts.md", line 259, characters 53-54
+        Label definition:
+        File "basic.exts.md", line 262, characters 1-2
+      Text:
+      File "basic.exts.md", line 259, characters 55-56
+      Link:
+      File "basic.exts.md", line 259, characters 56-68
+        Text:
+        File "basic.exts.md", line 259, characters 57-67
+        Label:
+        File "basic.exts.md", line 259, characters 57-67
+        Label definition:
+        File "basic.exts.md", line 261, characters 1-11
+      Text:
+      File "basic.exts.md", line 259, characters 68-71
+      Link:
+      File "basic.exts.md", line 259, characters 71-85
+        Text:
+        File "basic.exts.md", line 259, characters 72-81
+        Label:
+        File "basic.exts.md", line 259, characters 83-84
+        Label definition:
+        File "basic.exts.md", line 262, characters 1-2
+      Text:
+      File "basic.exts.md", line 259, characters 85-97
+  Blank line:
+  File "basic.exts.md", line 260
+
+
+Unknown Cmarkit block
+
+
+Unknown Cmarkit block
   Blank line:
   File "basic.exts.md", line 263
   Paragraph:
-  File "basic.exts.md", line 264, characters 0-26
-    Inlines:
-    File "basic.exts.md", line 264, characters 0-26
-      Text:
-      File "basic.exts.md", line 264, characters 0-2
-      Link:
-      File "basic.exts.md", line 264, characters 2-24
-        Text:
-        File "basic.exts.md", line 264, characters 3-4
-        Label:
-        File "basic.exts.md", line 264, characters 6-23
-        Label definition:
-        File "basic.exts.md", line 267, characters 1-18
-      Text:
-      File "basic.exts.md", line 264, characters 24-26
+  File "basic.exts.md", line 264, characters 0-55
+    Text:
+    File "basic.exts.md", line 264, characters 0-55
   Blank line:
   File "basic.exts.md", line 265
+  Paragraph:
+  File "basic.exts.md", line 266, characters 0-26
+    Inlines:
+    File "basic.exts.md", line 266, characters 0-26
+      Text:
+      File "basic.exts.md", line 266, characters 0-2
+      Link:
+      File "basic.exts.md", line 266, characters 2-24
+        Text:
+        File "basic.exts.md", line 266, characters 3-4
+        Label:
+        File "basic.exts.md", line 266, characters 6-23
+        Label definition:
+        File "basic.exts.md", line 269, characters 1-18
+      Text:
+      File "basic.exts.md", line 266, characters 24-26
+  Blank line:
+  File "basic.exts.md", line 267
 
 
 Unknown Cmarkit block
   Blank line:
-  File "basic.exts.md", line 268
-  Paragraph:
-  File "basic.exts.md", line 269, characters 0-47
-    Text:
-    File "basic.exts.md", line 269, characters 0-47
-  Blank line:
   File "basic.exts.md", line 270
   Paragraph:
-  File "basic.exts.md", line 271, characters 0-28
-    Inlines:
-    File "basic.exts.md", line 271, characters 0-28
-      Text:
-      File "basic.exts.md", line 271, characters 0-2
-      Link:
-      File "basic.exts.md", line 271, characters 2-26
-        Text:
-        File "basic.exts.md", line 271, characters 3-4
-        Label:
-        File "basic.exts.md", line 271, characters 6-25
-        Label definition:
-        File "basic.exts.md", line 274, characters 1-20
-      Text:
-      File "basic.exts.md", line 271, characters 26-28
+  File "basic.exts.md", line 271, characters 0-47
+    Text:
+    File "basic.exts.md", line 271, characters 0-47
   Blank line:
   File "basic.exts.md", line 272
+  Paragraph:
+  File "basic.exts.md", line 273, characters 0-28
+    Inlines:
+    File "basic.exts.md", line 273, characters 0-28
+      Text:
+      File "basic.exts.md", line 273, characters 0-2
+      Link:
+      File "basic.exts.md", line 273, characters 2-26
+        Text:
+        File "basic.exts.md", line 273, characters 3-4
+        Label:
+        File "basic.exts.md", line 273, characters 6-25
+        Label definition:
+        File "basic.exts.md", line 276, characters 1-20
+      Text:
+      File "basic.exts.md", line 273, characters 26-28
+  Blank line:
+  File "basic.exts.md", line 274
   Link reference definition:
-  File "basic.exts.md", line 274, characters 0-41
+  File "basic.exts.md", line 276, characters 0-41
     Label:
-    File "basic.exts.md", line 274, characters 1-20
+    File "basic.exts.md", line 276, characters 1-20
     Defined label:
-    File "basic.exts.md", line 274, characters 1-20
+    File "basic.exts.md", line 276, characters 1-20
     Destination:
-    File "basic.exts.md", line 274, characters 23-41
+    File "basic.exts.md", line 276, characters 23-41
   Blank line:
-  File "basic.exts.md", line 275
+  File "basic.exts.md", line 277
   Blank line:
-  File "basic.exts.md", line 276
+  File "basic.exts.md", line 278

--- a/vendor/github.com/panglesd/cmarkit/test/expect/basic.exts.strip-attributes.md
+++ b/vendor/github.com/panglesd/cmarkit/test/expect/basic.exts.strip-attributes.md
@@ -181,71 +181,55 @@ This is an empty table with three columns:
 
 ### Block attributes
 
-{#my-id}
 This is a paragraph with the `my-id` is.
 
-{#your-id}
 I have `your-id`, not mine
 
-{#his-id}
 I have `his-id`, not mine, not yours
 
-{.blue}
 #### This is a title with the `.blue` class
 
-{key=value}
 - This is an item where `key` has value `value`.
 - It is not possible to attach attributes to list items... yet
 
-{#my-id .my-class key="value" flag}
 I'm a paragraph with many attributes
 
-{#my-id .my-class2 .my-class key2="value2" flag2 key="value" flag}
 I have much more attribute than the previous one, since they stack
 
-{#your-id}
 I have your id
 
-{.class1 .class3 .class2 .class4}
 I have a lot of class: `class1`, `class2`, `class3` and `class4`
 
-{.class4 .class1 .class3 .class2}
 Me too\!
 
-{#space-do-not-matter}
 But spaceships matter.
 
-{key="a value with a }"}
 Some word
 
-{introducing standalone attributes}
 
-{#attributes .standalone also="stack"}
 
 ### Inline attributes
 
-[]{.I am} not a block attribute, but a standalone inline attribute, as I have content in the line.
+ not a block attribute, but a standalone inline attribute, as I have content in the line.
 
-In the middle of paragraphs, []{#attributes .inline} work.
+In the middle of paragraphs,  work.
 
-Similarly, at the end, they work []{as=well}
+Similarly, at the end, they work 
 
-Without specified delimitations, inline attributes are either []{standalone} or attached to the left-closest{word}.
+Without specified delimitations, inline attributes are either  or attached to the left-closest.
 
-Inline attributes can [refer to many]{words} including [with **inline**]{.bold}.
+Inline attributes can refer to many including with **inline**.
 
-Attributes can be nested: [link [with]{attrs}](example.com), [attrs [with
-link](example.com)]{attrs}, [attrs [within]{attrs1}]{attrs2}.
+Attributes can be nested: [link with](example.com), attrs [with
+link](example.com), attrs within.
 
-Attributes can be attached without squares, for instance this{#idee} has an
-id. This `codeblock`{#too}! This ![image](as){#well}. [Links](work){#the .same}. **Emphasis**{and} and *italic1*{and} _italic2_{too}\!
+Attributes can be attached without squares, for instance this has an
+id. This `codeblock`! This ![image](as). [Links](work). **Emphasis** and *italic1* _italic2_\!
 
-Testing ~~strikethrough~~{text}.
+Testing ~~strikethrough~~.
 
-{#id}
 ## Title with an id
 
-{#id}
 Title with an id
 ================
 
@@ -267,6 +251,5 @@ However, for link definition, they are present:
 
 A [b][link-def-with-attrs] c
 
-{.present}
 [link-def-with-attrs]: http://example.com
 

--- a/vendor/github.com/panglesd/cmarkit/test/expect/basic.exts.strip-attributes.md
+++ b/vendor/github.com/panglesd/cmarkit/test/expect/basic.exts.strip-attributes.md
@@ -238,18 +238,17 @@ Title with an id
 
 We can provide [attributes][a] definition to [avoid][a] [cluttering] a [line with][a] attributes.
 
-<!-- Unknown Cmarkit block -->
-<!-- Unknown Cmarkit block -->
 
 Attributes attached to attribute definition do nothing:
 
 A [b][attr-attached-def] c
 
-<!-- Unknown Cmarkit block -->
 
 However, for link definition, they are present:
 
 A [b][link-def-with-attrs] c
 
 [link-def-with-attrs]: http://example.com
+
+[^link-def-with]: Hello
 

--- a/vendor/github.com/panglesd/cmarkit/test/expect/basic.exts.trip.md
+++ b/vendor/github.com/panglesd/cmarkit/test/expect/basic.exts.trip.md
@@ -254,14 +254,15 @@ Title with an id
 
 We can provide [attributes][a] definition to [avoid][a] [cluttering] a [line with][a] attributes.
 
-<!-- Unknown Cmarkit block -->
-<!-- Unknown Cmarkit block -->
+[cluttering]:{#clut}
+[a]:{.important-word}
 
 Attributes attached to attribute definition do nothing:
 
 A [b][attr-attached-def] c
 
-<!-- Unknown Cmarkit block -->
+{.not-present}
+[attr-attached-def]:{.present}
 
 However, for link definition, they are present:
 
@@ -269,4 +270,8 @@ A [b][link-def-with-attrs] c
 
 {.present}
 [link-def-with-attrs]: http://example.com
+
+{.present}
+[^link-def-with]:{#ID}
+  Hello
 

--- a/vendor/github.com/panglesd/cmarkit/test/expect/basic.strip-attributes.md
+++ b/vendor/github.com/panglesd/cmarkit/test/expect/basic.strip-attributes.md
@@ -1,0 +1,194 @@
+Basic tests
+===========
+
+Basic tests for all CommonMark constructs.
+
+## Testing autolinks 
+
+This is an <http://example.org> and another one <you@example.org>.
+
+
+## Testing breaks 
+
+A line ending (not in a code span or HTML tag) that is preceded by two 
+   or more spaces and does not occur at the end of a block is parsed as a
+ hard line break.
+
+So this means we had softbreaks so far and now we get  \
+  a hard break     
+ and another one.
+
+> So this means we had softbreaks so far and now we get  \
+>   a hard break     
+>     and another one.
+> This is very soooft.
+
+## Testing code spans 
+
+This is a multi-line code`
+    code span `` it has backticks
+  in there`
+
+Sometimes code spans `` `can have
+   really ```
+ strange
+      layout ``. Do you fancy `` `A_polymorphic_variant `` ? 
+
+
+## Testing emphasis
+
+There is _more_ than *one syntax* for __emphasis__ and **strong
+emphasis**.  We should be careful about **embedded \* marker**. This
+will be **tricky \* to handle**. This *is not \*\* what* you want ?
+
+
+## Testing links, images and link reference definitions
+
+This is an ![inline image](
+  /heyho    (The
+    multine title))
+
+  That is totally [colla    psed][] and 
+    that is [`short cuted`]
+
+Shortcuts can be better than [full references][`short 
+cuted`] but not
+     always and we'd like to trip their [label][`short    cuted`].
+
+> [colla psed]: /hohoho "And again these 
+>   multi
+>     line titles"
+
+ [`short cuted`]:    /veryshort   "But very
+    important"
+  
+
+## Testing raw HTML
+
+Haha <a>a</a><b2
+               data="foo" > hihi this is not the end yet.
+
+foo <a href="\*" />u</a>
+
+>  Haha <a>a</a><b2
+>               data="foo" > hihi this is not the end yet.
+
+## Testing blank lines
+
+    
+     
+Impressive isn't it ?
+
+## Testing block quotes 
+
+
+  >   > How is 
+  >   > Nestyfing going on 
+  >   > These irregularities **will** normalize
+  >   > We keep only the first block quote indent 
+
+>  ## Further tests #######  
+
+  We need a little quote here
+>  It's warranted.
+
+
+## Testing code blocks
+
+``` layout after info is not kept
+```
+
+ ``` ocaml module M
+ 
+ type t = 
+ | A of int
+ | B of string
+ 
+ let square x = x *. x
+ ````   
+
+The indented code block: 
+
+    a b c d 
+     a b c d
+     a b c d
+      
+    
+    a
+       a b c
+
+
+> ``` ocaml module M
+> 
+> type t = 
+> | A of int
+> | B of string
+> 
+> let square x = x *. x
+> ````   
+
+
+## Testing headings 
+
+aaa
+aaaa
+========
+
+> bbb `hey`
+> bbbb
+> --------
+
+  # That's one way     
+  
+   ### It's a long way to the heading   
+
+## Testing HTML block 
+
+<aside>
+<p>There is no aside</p>
+</aside>
+
+* <aside>
+  <p>There is no aside</p>
+  </aside>
+
+## Testing lists 
+
+The `square` function is the root. There are reasons for this:
+
+ 1. There is no reason. There should be a reason or an <http://example.org> 
+2. Maybe that's the reason. But it may not be the reason. 
+ 3. Is reason the only tool ? 
+
+> Quoted bullets
+> * Is this important ? 
+* * Well it's in the spec
+* 
+Empty list item above
+
+## Testing paragraphs 
+
+   We really want your paragraph layout preserved. 
+        Really ? 
+      Really.
+    Really.
+Really.		
+
+
+>   We really want your paragraph layout preserved. 
+>        Really ? 
+>      Really.
+>    Really.
+> Really.		
+ 
+
+
+## Testing thematic breaks
+
+ ***
+  ---
+   ___
+
+_ _ _ _ _ 
+
+>  *******

--- a/vendor/github.com/panglesd/cmarkit/test/expect/bug-18.strip-attributes.md
+++ b/vendor/github.com/panglesd/cmarkit/test/expect/bug-18.strip-attributes.md
@@ -1,0 +1,7 @@
+# Issue \#18 
+
+When a list marker is followed by end of file, we crash.
+
+ - Item 1
+ - Item 2
+ - 

--- a/vendor/github.com/panglesd/cmarkit/test/expect/bugs.exts.strip-attributes.md
+++ b/vendor/github.com/panglesd/cmarkit/test/expect/bugs.exts.strip-attributes.md
@@ -1,0 +1,31 @@
+Bugs
+====
+
+Add a section for the bug and the CommonMark that triggers it as 
+follows:
+
+```
+# Bug #NUM
+
+The triggering CommonMark
+```
+
+# Bug \#10 
+
+In cells toplevel text nodes not at the beginning or end of the cell
+get dropped.
+
+|  Foo                    |
+|-------------------------|
+| `a` or `b`              |
+| before `a` or `b` after |
+| before `a` or `b`after  |
+| before`a`or`b`after     |
+| *a*`a`                  |
+| <p>foo</p>              |
+
+# Bug \#15 
+
+Invalid markup generated for cancelled task.
+
+* [~] This has been cancelled

--- a/vendor/github.com/panglesd/cmarkit/test/expect/bugs.strip-attributes.md
+++ b/vendor/github.com/panglesd/cmarkit/test/expect/bugs.strip-attributes.md
@@ -1,0 +1,32 @@
+Bugs
+====
+
+Add a section for the bug and the CommonMark that triggers it as 
+follows:
+
+```
+# Issue #NUM
+
+The triggering CommonMark
+```
+
+# Issue \#11
+
+Escape ordered item markers at the beginning of paragraphs correctly.
+These should be paragraphs when rendered to markdown not list items.
+
+1\.
+
+2\.
+
+23\.
+
+
+24\)
+
+1234567890. This is not a list marker no need to escape it.
+
+
+
+
+

--- a/vendor/github.com/panglesd/cmarkit/test/test.ml
+++ b/vendor/github.com/panglesd/cmarkit/test/test.ml
@@ -14,7 +14,7 @@ let test_mapper_table_bug_14 () =
   let doc = Cmarkit.Doc.of_string ~layout:true ~strict:false table in
   let mdoc = Cmarkit.Mapper.map_doc (Cmarkit.Mapper.make ()) doc in
   print_endline "Expectation for mapper table bug #14:\n";
-  print_endline (Cmarkit_commonmark.of_doc mdoc);
+  print_endline (Cmarkit_commonmark.of_doc ~include_attributes:false mdoc);
   ()
 
 let main () =

--- a/vendor/github.com/panglesd/cmarkit/test/trip_spec.ml
+++ b/vendor/github.com/panglesd/cmarkit/test/trip_spec.ml
@@ -151,7 +151,7 @@ let test (t : Spec.test) ~show_diff =
   (* Parse with layout, render commonmark, if not equal reparse the render
      and render it to HTML, if that succeeds it's a correct rendering. *)
   let doc = Cmarkit.Doc.of_string ~layout:true t.markdown in
-  let md = Cmarkit_commonmark.of_doc doc in
+  let md = Cmarkit_commonmark.of_doc ~include_attributes:true doc in
   let has_notrip_reason =
     Option.is_some (List.assoc_opt t.example notrip_reasons)
   in
@@ -188,7 +188,7 @@ let test (t : Spec.test) ~show_diff =
 let test_no_layout (t : Spec.test) =
   (* Parse without layout, render commonmark, reparse, render to HTML *)
   let doc = Cmarkit.Doc.of_string ~layout:false t.markdown in
-  let md = Cmarkit_commonmark.of_doc doc in
+  let md = Cmarkit_commonmark.of_doc ~include_attributes:true doc in
   let doc' = Cmarkit.Doc.of_string md in
   let html = Cmarkit_renderer.doc_to_string renderer doc' in
   if String.equal html t.html then Ok () else


### PR DESCRIPTION
Fix #71.

Useful to interact with the content with other tools that do not understand attributes!

CC @patricoferris ! Does that work in your usecase? (in case you want to test but do not want to compile locally, you can use the binary produced by the CI)