### PR TITLE
Script execution improvements

### DIFF
--- a/src/engine/step/actions.ml
+++ b/src/engine/step/actions.ml
@@ -93,7 +93,7 @@ module AttributeActions = struct
       let arg =
         Jv.obj
           [|
-            ( "set_class",
+            ( "set_style",
               Jv.callback ~arity:3 @@ fun elem style value ->
               let old_value =
                 let old_value = Brr.El.inline_style style elem in
@@ -106,6 +106,17 @@ module AttributeActions = struct
                 match old_value with
                 | None -> Brr.El.remove_inline_style style elem
                 | Some old_value -> Brr.El.set_inline_style style old_value elem
+              in
+              undos_ref := undo :: !undos_ref;
+              Jv.callback ~arity:1 undo );
+            ( "set_class",
+              Jv.callback ~arity:3 @@ fun elem class_ bool ->
+              let bool = Jv.to_bool bool in
+              Brr.Console.(log [ "set_class called with"; elem; class_; bool ]);
+              let old_value = Brr.El.class' class_ elem in
+              Brr.El.set_class class_ bool elem;
+              let undo _ =
+                Fut.return @@ Brr.El.set_class class_ old_value elem
               in
               undos_ref := undo :: !undos_ref;
               Jv.callback ~arity:1 undo );

--- a/src/engine/step/actions.ml
+++ b/src/engine/step/actions.ml
@@ -115,7 +115,12 @@ module AttributeActions = struct
       in
       Undoable.return ~undo ()
     in
-    act_on_elems "exec-at-unpause" action elem
+    try act_on_elems "exec-at-unpause" action elem
+    with e ->
+      Brr.Console.(
+        log
+          [ "An exception occurred when trying to execute a custom script:"; e ]);
+      Undoable.return ()
 
   let do_ window elem =
     let do_ =


### PR DESCRIPTION
- Fix the fact that an error in a script would crash the engine
- Add an automatic undo generation for scripts: if no explicit undo are returned, but `slip` functions are called, we can deduce an undo function
- Add a `set_class` function (and fix the naming of the `set_style` function).