### PR TITLE
Don't cover presentation with table of content.

### DIFF
--- a/src/compiler/lib/slipshow.ml
+++ b/src/compiler/lib/slipshow.ml
@@ -53,19 +53,19 @@ let embed_in_page content ~has_math ~math_link ~slip_css_link ~slipshow_js_link
     %s
   </head>
   <body>
-    <div id="slipshow-content">
-      <svg id="slipshow-drawing-elem" style="overflow:visible; position: absolute; z-index:1000"></svg>
-      <div class="slipshow-rescaler">
-        <div class="slip">
-          <div class="slip-body">
-            %s
+    <div id="slipshow-main">
+      <div id="slipshow-content">
+        <svg id="slipshow-drawing-elem" style="overflow:visible; position: absolute; z-index:1000"></svg>
+        <div class="slipshow-rescaler">
+          <div class="slip">
+            <div class="slip-body">
+              %s
+            </div>
           </div>
         </div>
       </div>
+      <div id="slipshow-counter">0</div>
     </div>
-    <div id="slipshow-counter">0</div>
-
-
 
     <!-- Include the library -->
     %s

--- a/src/engine/normalization/normalization.css
+++ b/src/engine/normalization/normalization.css
@@ -1,5 +1,19 @@
+body {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  display: flex;
+}
+
+#slipshow-main {
+  position: relative;
+  flex-grow: 1;
+}
+
 #slipshow-open-window {
-  position: fixed;
+  position: absolute;
   overflow: hidden;
   background-color: white;
 }

--- a/src/engine/table_of_content/table_of_content.css
+++ b/src/engine/table_of_content/table_of_content.css
@@ -3,13 +3,13 @@
 }
 
 #slipshow-toc {
-  position: fixed;
   overflow: scroll;
   opacity: 0.98;
   top: 0;
   left: 0;
   bottom: 0;
   min-width: 25%;
+  max-width: 30%;
   padding: 30px;
   background: rosybrown;
   display: none;
@@ -27,9 +27,12 @@
   margin-right: 10px;
 }
 
-.slipshow-toc-only-step,
-.slipshow-toc-content {
+.slipshow-toc-only-step {
   display: inline-block;
+}
+
+.slipshow-toc-content {
+  display: inline;
 }
 
 .slipshow-toc-entry {

--- a/src/engine/table_of_content/table_of_content.ml
+++ b/src/engine/table_of_content/table_of_content.ml
@@ -55,7 +55,7 @@ let categorize window step el =
         let content = Brr.El.prop inner_text el in
         (content, Brr.El.tag_name el)
     | _ ->
-        let cap = 80 in
+        let cap = 100 in
         let content = Jstr.slice ~stop:cap (Brr.El.prop inner_text el) in
         let content =
           if Jstr.length (Brr.El.prop inner_text el) > cap then

--- a/test/compiler/simple.t/run.t
+++ b/test/compiler/simple.t/run.t
@@ -4,16 +4,16 @@ We can compile the file using the slip_of_mark binary
 
   $ cat file.html | grep "<body>" -A 10
     <body>
-      <div id="slipshow-content">
-        <svg id="slipshow-drawing" style="overflow:visible; position: absolute; z-index:1000"></svg>
-        <div class="slip-rescaler">
-          <div class="slip">
-            <div class="slip-body">
-              <h1 id="a-title"><a class="anchor" aria-hidden="true" href="#a-title"></a><span>A title</span></h1>
+      <div id="slipshow-main">
+        <div id="slipshow-content">
+          <svg id="slipshow-drawing-elem" style="overflow:visible; position: absolute; z-index:1000"></svg>
+          <div class="slipshow-rescaler">
+            <div class="slip">
+              <div class="slip-body">
+                <h1 id="a-title"><a class="anchor" aria-hidden="true" href="#a-title"></a><span>A title</span></h1>
   <div pause></div>
   <p><span>A word </span><span id="id" step emph-at-unpause>and</span><span> some other words.</span></p>
   <div pause></div>
-  <h2 id="subtitle"><a class="anchor" aria-hidden="true" href="#subtitle"></a><span>subtitle</span></h2>
 
 $ du -h file.html
 184K	file.html
@@ -41,16 +41,16 @@ If we do not pass an input file, it gets its value from stdin
 
   $ cat file.html | grep "<body>" -A 10
     <body>
-      <div id="slipshow-content">
-        <svg id="slipshow-drawing" style="overflow:visible; position: absolute; z-index:1000"></svg>
-        <div class="slip-rescaler">
-          <div class="slip">
-            <div class="slip-body">
-              <h1 id="title"><a class="anchor" aria-hidden="true" href="#title"></a><span>Title</span></h1>
+      <div id="slipshow-main">
+        <div id="slipshow-content">
+          <svg id="slipshow-drawing-elem" style="overflow:visible; position: absolute; z-index:1000"></svg>
+          <div class="slipshow-rescaler">
+            <div class="slip">
+              <div class="slip-body">
+                <h1 id="title"><a class="anchor" aria-hidden="true" href="#title"></a><span>Title</span></h1>
   <p><span>Paragraph</span></p>
   
-            </div>
-          </div>
+              </div>
 
 If we give neither the input nor the output, stdin and stdout are used:
 
@@ -100,4 +100,4 @@ Images
 
   $ slipshow file_with_image.md
   $ cat file_with_image.html | grep image | grep base64
-              <p><span>A paragraph with an </span><img src="data:;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAIAAAACUFjqAAABg2lDQ1BJQ0MgcHJvZmlsZQAAKJF9kT1Iw0AcxV9bpaIVB4OIOGSoTnZREcdahSJUCLVCqw4ml35Bk4YkxcVRcC04+LFYdXBx1tXBVRAEP0BcXZwUXaTE/yWFFjEeHPfj3b3H3Tsg2KgwzeqKA5pum+lkQszmVsXwK/ogIIIhCDKzjDlJSsF3fN0jwNe7GM/yP/fn6FfzFgMCInGcGaZNvEE8s2kbnPeJBVaSVeJz4gmTLkj8yHXF4zfORZeDPFMwM+l5YoFYLHaw0sGsZGrE08RRVdMpP5j1WOW8xVmr1FjrnvyFkby+ssx1mqNIYhFLkCBCQQ1lVGAjRqtOioU07Sd8/COuXyKXQq4yGDkWUIUG2fWD/8Hvbq3C1KSXFEkA3S+O8zEGhHeBZt1xvo8dp3kChJ6BK73trzaA2U/S620tegQMbAMX121N2QMud4DhJ0M2ZVcK0QwWCsD7GX1TDhi8BXrXvN5a+zh9ADLUVeoGODgExouUve7z7p7O3v490+rvB2/RcqXOpP/kAAAACXBIWXMAAC4jAAAuIwF4pT92AAAAB3RJTUUH5wsUDBghqFYBIAAAABl0RVh0Q29tbWVudABDcmVhdGVkIHdpdGggR0lNUFeBDhcAAACeSURBVBjTbY4xCoQwFEQny1aWCVFPkEKTK4SAeATv5wE8gjew+wpewV/aB9xC1Cz4qhkeDIPjYhzHruuGYTgScCciUkp571P9wYVzLsYopUTCd55nAHmen31dV2YuigIAM6OqKmPM6YQQAO4KQEzTtO87AGttWZZZlvV9T0QhhKZpnmvbthlj6rp+v/bKo5dlYea2bf98Oq61JqJ0/AfIKIeErZAqOwAAAABJRU5ErkJggg==" alt="image" ></p>
+                <p><span>A paragraph with an </span><img src="data:;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAIAAAACUFjqAAABg2lDQ1BJQ0MgcHJvZmlsZQAAKJF9kT1Iw0AcxV9bpaIVB4OIOGSoTnZREcdahSJUCLVCqw4ml35Bk4YkxcVRcC04+LFYdXBx1tXBVRAEP0BcXZwUXaTE/yWFFjEeHPfj3b3H3Tsg2KgwzeqKA5pum+lkQszmVsXwK/ogIIIhCDKzjDlJSsF3fN0jwNe7GM/yP/fn6FfzFgMCInGcGaZNvEE8s2kbnPeJBVaSVeJz4gmTLkj8yHXF4zfORZeDPFMwM+l5YoFYLHaw0sGsZGrE08RRVdMpP5j1WOW8xVmr1FjrnvyFkby+ssx1mqNIYhFLkCBCQQ1lVGAjRqtOioU07Sd8/COuXyKXQq4yGDkWUIUG2fWD/8Hvbq3C1KSXFEkA3S+O8zEGhHeBZt1xvo8dp3kChJ6BK73trzaA2U/S620tegQMbAMX121N2QMud4DhJ0M2ZVcK0QwWCsD7GX1TDhi8BXrXvN5a+zh9ADLUVeoGODgExouUve7z7p7O3v490+rvB2/RcqXOpP/kAAAACXBIWXMAAC4jAAAuIwF4pT92AAAAB3RJTUUH5wsUDBghqFYBIAAAABl0RVh0Q29tbWVudABDcmVhdGVkIHdpdGggR0lNUFeBDhcAAACeSURBVBjTbY4xCoQwFEQny1aWCVFPkEKTK4SAeATv5wE8gjew+wpewV/aB9xC1Cz4qhkeDIPjYhzHruuGYTgScCciUkp571P9wYVzLsYopUTCd55nAHmen31dV2YuigIAM6OqKmPM6YQQAO4KQEzTtO87AGttWZZZlvV9T0QhhKZpnmvbthlj6rp+v/bKo5dlYea2bf98Oq61JqJ0/AfIKIeErZAqOwAAAABJRU5ErkJggg==" alt="image" ></p>


### PR DESCRIPTION
Before the computed size of the window to the universe was based on the browser window dimensions. Now it is based on the parent element dimension.

This allows to have the table of content not cover the presentation.