### PR TITLE
Namespace classes and ids to avoid clash

### DIFF
--- a/docs/themes.rst
+++ b/docs/themes.rst
@@ -3,45 +3,14 @@
 Themes
 ========
 
-Using a theme
----------------------------
+Theme support is a work in progress!
 
-Just add the following line in the end of the head tag:
+In the meantime, you can add CSS (inline or via a link) directly in your
+presentation. Here is a non exhaustive list of CSS selector you might be
+interested in tweaking:
 
-.. code-block:: html
-
-    <link rel="stylesheet" type="text/css" href="<link to your style>.css">
-
-Theme list
----------------------------
-
-Slipshow comes with its set of themes.
-
-* Theme ``Vanier``:
-
-.. code-block:: html
-
-    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/slipshow@0.0.18/dist/css/themes/vanier/vanier.css">
-
-
-If you want your theme
-    
-Writing a theme
----------------------------
-
-You need to define the css of at least the following attributes:
-
-* The rule ``#universe`` for the canvas,
-* The rule ``slip-slip`` for the slips,
-* The rule ``slip-title`` for slip titles,
-* The rule ``slip-body`` for the inside of the slips,
-* The rule ``.emphasize`` for emphasized content,
-* The rules ``.block``, ``.theorem``, ``.lemma``, ``.definition``, ``.example``, ``.corollary``, ``.remark``, with special rules when they have the attribute ``title`` defined,
-* The rule ``.cpt-slip`` for the counter (bottom right by default),
-* The rules ``.toc-slip`` and ``.toc-slip li`` for the table of content,
-* The rule ``.toc-slip .before`` for the entries of the table of content already seen,
-* The rule ``.toc-slip .current`` for the entry of the table of content where we are,
-* The rule ``.toc-slip .after`` for the entries of the table of content to come,
-* The rule ``.toc-slip .toc-function`` for the entries of the table of content that are clickable,
-
-You can also add any additionnal rules, such as ``h1``, that are not specific to ``slipshow``.
+* ``.slip-body`` to restyle a slip, eg to add margin, set font size and color...
+* ``.block``, ``.theorem``, ``.lemma``, ``.definition``, ``.example``,
+  ``.corollary``, ``.remark``, for admonitions (with special rules when they
+  have the attribute ``title`` defined),
+* Any non-specific elements, such as titles, paragraphs, ...

--- a/src/compiler/lib/slipshow.ml
+++ b/src/compiler/lib/slipshow.ml
@@ -55,7 +55,7 @@ let embed_in_page content ~has_math ~math_link ~slip_css_link ~slipshow_js_link
   <body>
     <div id="slipshow-content">
       <svg id="slipshow-drawing-elem" style="overflow:visible; position: absolute; z-index:1000"></svg>
-      <div class="slip-rescaler">
+      <div class="slipshow-rescaler">
         <div class="slip">
           <div class="slip-body">
             %s

--- a/src/compiler/lib/slipshow.ml
+++ b/src/compiler/lib/slipshow.ml
@@ -54,7 +54,7 @@ let embed_in_page content ~has_math ~math_link ~slip_css_link ~slipshow_js_link
   </head>
   <body>
     <div id="slipshow-content">
-      <svg id="slipshow-drawing" style="overflow:visible; position: absolute; z-index:1000"></svg>
+      <svg id="slipshow-drawing-elem" style="overflow:visible; position: absolute; z-index:1000"></svg>
       <div class="slip-rescaler">
         <div class="slip">
           <div class="slip-body">

--- a/src/compiler/lib/slipshow.ml
+++ b/src/compiler/lib/slipshow.ml
@@ -63,7 +63,7 @@ let embed_in_page content ~has_math ~math_link ~slip_css_link ~slipshow_js_link
         </div>
       </div>
     </div>
-    <div id="slip-counter">0</div>
+    <div id="slipshow-counter">0</div>
 
 
 

--- a/src/engine/controller.ml
+++ b/src/engine/controller.ml
@@ -7,7 +7,7 @@ let keyboard_setup (window : Universe.Window.window) =
       match key with
       | "t" ->
           let body = Brr.Document.body Brr.G.document in
-          let c = Jstr.v "slip-toc-mode" in
+          let c = Jstr.v "slipshow-toc-mode" in
           Brr.El.set_class c (not @@ Brr.El.class' c body) body
       | "w" -> Drawing.State.set_tool Pen
       | "h" -> Drawing.State.set_tool Highlighter

--- a/src/engine/drawing/drawing.css
+++ b/src/engine/drawing/drawing.css
@@ -1,16 +1,16 @@
 
-.drawing #open-window {
+.slipshow-drawing-mode #open-window {
   pointer-events: none;
 }
 
-#slip-drawing-toolbar {
+#slipshow-drawing-toolbar {
   position: fixed;
   top: 0;
   left: 0;
 }
 
 .slip-writing-toolbar:hover,
-.drawing .slip-writing-toolbar {
+.slipshow-drawing-mode .slip-writing-toolbar {
   width: 32px;
   height: 640px;
 }

--- a/src/engine/drawing/drawing.css
+++ b/src/engine/drawing/drawing.css
@@ -1,5 +1,5 @@
 
-.slipshow-drawing-mode #open-window {
+.slipshow-drawing-mode #slipshow-open-window {
   pointer-events: none;
 }
 

--- a/src/engine/drawing/drawing.ml
+++ b/src/engine/drawing/drawing.ml
@@ -106,11 +106,11 @@ end = struct
 
   let make_active () =
     let body = Brr.Document.body Brr.G.document in
-    Brr.El.set_class (Jstr.v "drawing") true body
+    Brr.El.set_class (Jstr.v "slipshow-drawing-mode") true body
 
   let make_inactive () =
     let body = Brr.Document.body Brr.G.document in
-    Brr.El.set_class (Jstr.v "drawing") false body
+    Brr.El.set_class (Jstr.v "slipshow-drawing-mode") false body
 
   let set_tool t =
     let () =
@@ -288,11 +288,12 @@ let setup el =
               </div>
           </div> |}
   in
-  let d = Brr.El.div ~at:[ Brr.At.id (Jstr.v "slip-drawing-toolbar") ] [] in
+  let d = Brr.El.div ~at:[ Brr.At.id (Jstr.v "slipshow-drawing-toolbar") ] [] in
   Jv.set (Brr.El.to_jv d) "innerHTML" (Jv.of_string content);
   Brr.El.append_children el [ d ];
   let svg =
-    Brr.El.find_first_by_selector (Jstr.v "#slipshow-drawing") |> Option.get
+    Brr.El.find_first_by_selector (Jstr.v "#slipshow-drawing-elem")
+    |> Option.get
   in
   let _ : unit Fut.t =
     let open Fut.Syntax in

--- a/src/engine/normalization/normalization.css
+++ b/src/engine/normalization/normalization.css
@@ -1,9 +1,9 @@
-#open-window {
+#slipshow-open-window {
   position: fixed;
   overflow: hidden;
   background-color: white;
 }
 
-.format-container {
+.slipshow-format-container {
   transform-origin: top left;
 }

--- a/src/engine/normalization/normalization.ml
+++ b/src/engine/normalization/normalization.ml
@@ -69,10 +69,12 @@ let replace_open_window window =
 
 let create el =
   let format_container =
-    Brr.El.div ~at:[ Brr.At.class' (Jstr.v "format-container") ] []
+    Brr.El.div ~at:[ Brr.At.class' (Jstr.v "slipshow-format-container") ] []
   in
   let open_window =
-    Brr.El.div ~at:[ Brr.At.id (Jstr.v "open-window") ] [ format_container ]
+    Brr.El.div
+      ~at:[ Brr.At.id (Jstr.v "slipshow-open-window") ]
+      [ format_container ]
   in
   Brr.El.insert_siblings `Replace el [ open_window ];
   Brr.El.append_children format_container [ el ];

--- a/src/engine/rescale/rescale.css
+++ b/src/engine/rescale/rescale.css
@@ -5,7 +5,7 @@
   border: 1px solid transparent;
 }
 
-.slip-rescaler {
+.slipshow-rescaler {
   overflow-x: hidden;
   overflow-y: hidden;
   width: unset;

--- a/src/engine/rescale/rescale.ml
+++ b/src/engine/rescale/rescale.ml
@@ -1,9 +1,12 @@
 open Brr
 
-(* We need to listen on resize for both slip-rescalers (the containers) as well as their only child. *)
+(* We need to listen on resize for both slipshow-rescalers (the containers) as well as their only child. *)
 let setup_rescalers () =
   let slip_rescalers =
-    El.fold_find_by_selector (fun x a -> x :: a) (Jstr.v ".slip-rescaler") []
+    El.fold_find_by_selector
+      (fun x a -> x :: a)
+      (Jstr.v ".slipshow-rescaler")
+      []
   in
   let slips =
     List.filter_map
@@ -26,7 +29,8 @@ let setup_rescalers () =
     | [] | _ :: _ :: _ -> fun () -> Console.(log [ "problem!" ])
   in
   let rescale entry =
-    if Brr.El.class' (Jstr.v "slip-rescaler") entry then rescaled_rescaler entry
+    if Brr.El.class' (Jstr.v "slipshow-rescaler") entry then
+      rescaled_rescaler entry
     else
       match Brr.El.parent entry with
       | None -> fun () -> ()

--- a/src/engine/step/actions.ml
+++ b/src/engine/step/actions.ml
@@ -153,7 +153,8 @@ let update_pause_ancestors () =
     | None -> Undoable.return ()
     | Some elem ->
         let rec hide_parent elem =
-          if Brr.El.class' (Jstr.v "universe") elem then Undoable.return ()
+          if Brr.El.class' (Jstr.v "slipshow-universe") elem then
+            Undoable.return ()
           else
             let> () = set_class "pauseAncestor" true elem in
             match Brr.El.parent elem with

--- a/src/engine/step/actions.ml
+++ b/src/engine/step/actions.ml
@@ -171,7 +171,7 @@ let update_history () =
   let n = State.get_step () in
   let> () =
     let counter =
-      Brr.El.find_first_by_selector (Jstr.v "#slip-counter") |> Option.get
+      Brr.El.find_first_by_selector (Jstr.v "#slipshow-counter") |> Option.get
     in
     Undoable.return ~undo:(fun () ->
         Fut.return

--- a/src/engine/step/next.ml
+++ b/src/engine/step/next.ml
@@ -30,18 +30,19 @@ let ( !! ) = Jstr.v
 let actualize () =
   let () =
     Brr.El.fold_find_by_selector
-      (fun el () -> Brr.El.set_class !!"slip-current-step" false el)
-      !!".slip-current-step" ()
+      (fun el () -> Brr.El.set_class !!"slipshow-toc-current-step" false el)
+      !!".slipshow-toc-current-step"
+      ()
   in
   let () =
     match
       Brr.El.find_first_by_selector
-        !!(".slip-step-" ^ string_of_int (State.get_step ()))
+        !!(".slipshow-toc-step-" ^ string_of_int (State.get_step ()))
     with
     | None -> ()
     | Some el ->
         Brr.El.scroll_into_view ~align_v:`Nearest ~behavior:`Smooth el;
-        Brr.El.set_class !!"slip-current-step" true el
+        Brr.El.set_class !!"slipshow-toc-current-step" true el
   in
   Messaging.send_step ()
 

--- a/src/engine/step/step.css
+++ b/src/engine/step/step.css
@@ -15,7 +15,7 @@
   opacity: 0;
 }
 
-#slip-counter {
+#slipshow-counter {
   position: fixed;
   bottom: 0;
   right: 0;

--- a/src/engine/table_of_content/table_of_content.css
+++ b/src/engine/table_of_content/table_of_content.css
@@ -1,8 +1,8 @@
-.slip-toc-mode #slip-toc {
+.slipshow-toc-mode #slipshow-toc {
   display: block;
 }
 
-#slip-toc {
+#slipshow-toc {
   position: fixed;
   overflow: scroll;
   opacity: 0.98;
@@ -16,7 +16,7 @@
   z-index: 100;
 }
 
-.slip-step {
+.slipshow-toc-step {
   display: inline-block;
   border: 1px solid black;
   border-radius: 3px;
@@ -27,15 +27,15 @@
   margin-right: 10px;
 }
 
-.slip-only-step,
-.slip-toc-content {
+.slipshow-toc-only-step,
+.slipshow-toc-content {
   display: inline-block;
 }
 
-.slip-toc-entry {
+.slipshow-toc-entry {
   cursor: pointer;
 }
 
-.slip-current-step .slip-step {
+.slipshow-toc-current-step .slipshow-toc-step {
   background-color: red;
 }

--- a/src/engine/table_of_content/table_of_content.ml
+++ b/src/engine/table_of_content/table_of_content.ml
@@ -8,7 +8,7 @@ let entry window step ~tag_name ~content =
     | Some step ->
         [
           Brr.El.div
-            ~at:[ Brr.At.class' !!"slip-step" ]
+            ~at:[ Brr.At.class' !!"slipshow-toc-step" ]
             [ Brr.El.txt Jstr.(of_int step + !!".") ];
         ]
   in
@@ -17,20 +17,21 @@ let entry window step ~tag_name ~content =
     else
       [
         Brr.El.v tag_name
-          ~at:[ Brr.At.class' !!"slip-toc-content" ]
+          ~at:[ Brr.At.class' !!"slipshow-toc-content" ]
           [ Brr.El.txt content ];
       ]
   in
   let at =
-    if Jstr.is_empty content then [ Brr.At.class' !!"slip-only-step" ] else []
+    if Jstr.is_empty content then [ Brr.At.class' !!"slipshow-toc-only-step" ]
+    else []
   in
   let el = Brr.El.div ~at (step_elem @ content_elem) in
   let () =
     match step with
     | None -> ()
     | Some step ->
-        Brr.El.set_class !!"slip-toc-entry" true el;
-        Brr.El.set_class !!("slip-step-" ^ string_of_int step) true el;
+        Brr.El.set_class !!"slipshow-toc-entry" true el;
+        Brr.El.set_class !!("slipshow-toc-step-" ^ string_of_int step) true el;
         let _unistener =
           Brr.Ev.listen Brr.Ev.click
             (fun _ ->
@@ -78,5 +79,5 @@ let generate window root =
     |> snd |> List.rev
   in
   let els = entry window (Some 0) ~tag_name:!!"div" ~content:!!"" :: els in
-  let toc_el = Brr.El.div ~at:[ Brr.At.id !!"slip-toc" ] els in
+  let toc_el = Brr.El.div ~at:[ Brr.At.id !!"slipshow-toc" ] els in
   Brr.El.append_children (Brr.Document.body Brr.G.document) [ toc_el ]

--- a/src/engine/themes/default.css
+++ b/src/engine/themes/default.css
@@ -6,7 +6,7 @@
   margin-right: 110px;
 }
 
-#universe {
+#slipshow-universe {
   font:
     30px "Fira Sans",
     sans-serif;

--- a/src/engine/themes/default.css
+++ b/src/engine/themes/default.css
@@ -12,7 +12,7 @@
     sans-serif;
 }
 
-h1:not(#slip-toc h1) {
+h1:not(#slipshow-toc h1) {
   text-align: center;
 }
 

--- a/src/engine/universe/coordinates.ml
+++ b/src/engine/universe/coordinates.ml
@@ -22,7 +22,7 @@ let get elem =
   let rec compute elem =
     match El.offset_parent elem with
     | None -> ((0., 0.), 1.)
-    | Some parent when El.class' (Jstr.v "universe") parent ->
+    | Some parent when El.class' (Jstr.v "slipshow-universe") parent ->
         (get_coord_in_parent elem, 1.)
     | Some parent ->
         let (cx, cy), parent_scale = compute parent in

--- a/src/engine/universe/universe.css
+++ b/src/engine/universe/universe.css
@@ -5,7 +5,7 @@ body {
   background-color: black;
 }
 
-#universe {
+#slipshow-universe {
   position: absolute;
   top: 0;
   left: 0;

--- a/src/engine/universe/window.ml
+++ b/src/engine/universe/window.ml
@@ -35,14 +35,20 @@ let setup el =
   let open Brr in
   let universe =
     El.div
-      ~at:[ At.class' (Jstr.v "universe movable"); At.id (Jstr.v "universe") ]
+      ~at:
+        [
+          At.class' (Jstr.v "slipshow-universe movable");
+          At.id (Jstr.v "slipshow-universe");
+        ]
       []
   in
   let scale_container =
-    El.div ~at:[ At.class' (Jstr.v "scale-container") ] [ universe ]
+    El.div ~at:[ At.class' (Jstr.v "slipshow-scale-container") ] [ universe ]
   in
   let rotate_container =
-    El.div ~at:[ At.class' (Jstr.v "rotate-container") ] [ scale_container ]
+    El.div
+      ~at:[ At.class' (Jstr.v "slipshow-rotate-container") ]
+      [ scale_container ]
   in
   Brr.El.insert_siblings `Replace el [ rotate_container ];
   Brr.El.append_children universe [ el ];


### PR DESCRIPTION
(Mostly) use `slipshow-`, with sometimes subgroups (eg `slipshow-toc-`).

More work needed as some css is leaking in the compiler! Also some toc abstraction is leaking in step.ml (I think to avoid circular dependency but that's not ideal).