### PR TITLE
Slipscripts improvements: `onUndo` and `state`

### DIFF
--- a/docs/syntax.rst
+++ b/docs/syntax.rst
@@ -191,11 +191,22 @@ These attributes are actions that will be executed when a ``pause`` or ``step`` 
 Custom scripts
 --------------
 
-Use a slipscript code block to add a script, and ``exec-at-unpause`` to execute it. The script should return the function to undo the change.
+Use a slipscript code block to add a script, and ``exec-at-unpause`` to execute it.
 
 .. code-block:: markdown
 
-		{exec-at-unpause}
+		{pause exec-at-unpause}
+		```slip-script
+                alert("Alerts are very annoying !")
+		```
+
+If a script has a "permanent" side-effect, it has to provide a way for slipshow
+to revert it. There are currently two experimental ways to do that. The first
+one (but not the preferred one) is return an undo function:
+
+.. code-block:: markdown
+
+		{pause exec-at-unpause}
 		```slip-script
                 let elem = document.querySelector("#id")
 		let old_value = elem.style.opacity;
@@ -203,24 +214,67 @@ Use a slipscript code block to add a script, and ``exec-at-unpause`` to execute 
                 return {undo : () => { elem.style.opacity = old_value }}
 		```
 
-Beware: experimental! Slip-scripts have access to a ``slip`` object, which they can use to programmatically call the functions above. Using such API registers an undo callback, and it is not needed to return an undo function.
+However this is not always easy to compose. The other option is to use
+the ``slip.onUndo`` function to register callbacks to be run on undo.
+
+		{pause exec-at-unpause}
+		```slip-script
+                let i = 0
+                let incr = () => {
+                  slip.onUndo(() => { console.log(--i)})
+                  console.log(i++);
+                }
+                incr();
+                incr();
+                incr();
+		```
+
+Using ``slip.onUndo`` inside an undo callback should not be a problem. (Actually, it might be recommended.)
+
+Slipshow provides a few utils function, using the callback mechanism just desribed.
+
+You can use ``slip.setStyle(elem, style, value)`` where ``elem`` is an element, and ``style`` and ``value`` a string to set a style and register an undo callback.
+
+You can also use ``slip.setClass(elem, className, bool)`` where ``elem`` is an element, ``style`` is a string and ``bool`` a boolean to add or remove a class and register an undo callback.
+
+You can also use ``slip.setProp(object, propName, value)`` where ``object`` is an element, ``propName`` is a string and ``value`` a value to set a property and register an undo callback.
+
+Through the ``slip`` object, slip-scripts also have access to the actions defined above. Again, they work using the ``onUndo`` callbacks. They can be used to programmatically call the actions defined above.
 
 .. code-block:: markdown
 
-		{exec-at-unpause}
+		{pause exec-at-unpause}
 		```slip-script
                 let elem = document.querySelector("#id")
                 slip.up(elem);
 		```
 
-Note that if a function above accepts multiple IDs (as ``unstatic-at-unpause`` for instance), then the function expects a list of elements:
+Note that if an API above accepts multiple IDs (as ``unstatic-at-unpause`` for instance), then the function expects a list of elements:
 
 .. code-block:: markdown
 
-		{exec-at-unpause}
+		{pause exec-at-unpause}
 		```slip-script
                 let elems = document.querySelectorAll(".class")
                 slip.unstatic(elems);
 		```
 
-In addition to the function above, you can use ``slip.setStyle(elem, style, value)`` where ``elem`` is an element, and ``style`` and ``value`` a string to set a style and register an undo callback. You can also use ``slip.setClass(elem, className, bool)`` where ``elem`` is an element, ``style`` is a string and ``bool`` a boolean to add or remove a class and register an undo callback.
+Finally, the ``slip.state`` object is persisted between scripts. (Other functions are specific to a script. This might change in the future, but ``slip.state`` is safe to use).
+
+Use it with ``slip.setProp`` to not forget undoing the changes!
+
+.. code-block:: markdown
+		{pause exec-at-unpause}
+		```slip-script
+                log = function (slip, x) { // slip needs to be passed
+                  console.log(x)
+                  slip.onUndo(() => {console.log(x)})
+                }
+                log(slip, slip.state.x);
+                slip.setProp(slip.state, "x", 1);
+                log(slip, slip.state.x);
+                ```
+		{pause exec-at-unpause}
+		```slip-script
+                log(slip, slip.state.x); // 1
+                ```

--- a/src/engine/step/javascript_api.ml
+++ b/src/engine/step/javascript_api.ml
@@ -41,6 +41,11 @@ let unreveal = one_elem_list Actions.unreveal
 let emph = one_elem_list Actions.emph
 let unemph = one_elem_list Actions.unemph
 
+let on_undo =
+  one_arg Fun.id @@ fun callback ->
+  let undo _ = Fut.return @@ ignore @@ Jv.apply callback [||] in
+  Undoable.return ~undo ()
+
 let slip window undos_ref =
   Jv.obj
     [|
@@ -57,4 +62,5 @@ let slip window undos_ref =
       ("unreveal", unreveal undos_ref);
       ("emph", emph undos_ref);
       ("unemph", unemph undos_ref);
+      ("onUndo", on_undo undos_ref);
     |]

--- a/src/engine/undoable/browser_.ml
+++ b/src/engine/undoable/browser_.ml
@@ -1,5 +1,11 @@
 open Monad
 
+let set_prop obj prop value =
+  let old_value = Jv.get' obj prop in
+  Jv.set' obj prop value;
+  let undo () = Fut.return @@ Jv.set' obj prop old_value in
+  return ~undo ()
+
 let set_class c b elem : unit t =
   let c = Jstr.v c in
   let old_class = Brr.El.class' c elem in

--- a/test/engine/basic.t/new_engine.md
+++ b/test/engine/basic.t/new_engine.md
@@ -1,5 +1,18 @@
 Salut !
 
+{pause exec-at-unpause}
+```slip-script
+let i = 0
+let incr = () => {
+  slip.onUndo(() => { console.log(--i)})
+  console.log(i++);
+}
+incr();
+incr();
+incr();
+```
+
+
 {#a .unstatic}
 [a]{#box1 .boxes}
 

--- a/test/engine/basic.t/new_engine.md
+++ b/test/engine/basic.t/new_engine.md
@@ -52,6 +52,11 @@ let elems = document.querySelectorAll(".boxes");
 slip.focus(elems);
 ```
 
+{pause exec-at-unpause}
+```slip-script
+slip.onUndo(() => { console.log("Undoing") })
+```
+
 
 Lorem ipsum dolor sit amet, consectetuer adipiscing elit.  Donec hendrerit tempor tellus.  Donec pretium posuere tellus.  Proin quam nisl, tincidunt et, mattis eget, convallis nec, purus.  Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.  Nulla posuere.  Donec vitae dolor.  Nullam tristique diam non turpis.  Cras placerat accumsan nulla.  Nullam rutrum.  Nam vestibulum accumsan nisl.
 

--- a/test/engine/basic.t/new_engine.md
+++ b/test/engine/basic.t/new_engine.md
@@ -2,6 +2,23 @@ Salut !
 
 {pause exec-at-unpause}
 ```slip-script
+log = function (slip, x) { // slip needs to be passed
+  console.log(x)
+  slip.onUndo(() => {console.log(x)})
+}
+log(slip, slip.state.x);
+slip.setProp(slip.state, "x", 1);
+log(slip, slip.state.x);
+```
+
+{pause exec-at-unpause}
+```slip-script
+log(slip, slip.state.x); // 1
+```
+
+
+{pause exec-at-unpause}
+```slip-script
 let i = 0
 let incr = () => {
   slip.onUndo(() => { console.log(--i)})


### PR DESCRIPTION
This PR adds two things in the `slip` object passed to scripts:

- A `slip.onUndo` value, that allows to register a callback to be run during undo (in reverse order).
- A `slip.state` object (initially empty) that is persisted between scripts.

Documentation is updated.

@meithecatte I would be grateful if you can test those changes! The CI should built binaries, so you don't have to build locally.