### PR TITLE
Actions: Allow to focus on multiple elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+- Allow to focus on multiple elements. Zooms as much as possible
+  so everything is visible, and center. Backward compatible, focusing
+  on a single element.
+
 ## [v0.1.1] Thursday 13th march, 2025. Lyon.
 
 Quick release mostly to allow publishing on opam!

--- a/src/engine/universe/coordinates.ml
+++ b/src/engine/universe/coordinates.ml
@@ -41,10 +41,34 @@ let get elem =
   { x; y; width; height }
 
 module Window_of_elem = struct
-  let focus elem =
-    let scale1 = width /. elem.width and scale2 = height /. elem.height in
-    let scale = Float.min scale1 scale2 in
-    { scale; x = elem.x; y = elem.y }
+  let focus ~current elems =
+    let box (b1 : element) (b2 : element) =
+      let left_x =
+        Float.min (b1.x -. (b1.width /. 2.)) (b2.x -. (b2.width /. 2.))
+      in
+      let right_x =
+        Float.max (b1.x +. (b1.width /. 2.)) (b2.x +. (b2.width /. 2.))
+      in
+      let top_y =
+        Float.min (b1.y -. (b1.height /. 2.)) (b2.y -. (b2.height /. 2.))
+      in
+      let bottom_y =
+        Float.max (b1.y +. (b1.height /. 2.)) (b2.y +. (b2.height /. 2.))
+      in
+      {
+        width = right_x -. left_x;
+        height = bottom_y -. top_y;
+        x = (right_x +. left_x) /. 2.;
+        y = (bottom_y +. top_y) /. 2.;
+      }
+    in
+    match elems with
+    | [] -> current
+    | elem :: elems ->
+        let box = List.fold_left box elem elems in
+        let scale1 = width /. box.width and scale2 = height /. box.height in
+        let scale = Float.min scale1 scale2 in
+        { scale; x = box.x; y = box.y }
 
   let enter elem =
     let scale = width /. elem.width in

--- a/src/engine/universe/coordinates.mli
+++ b/src/engine/universe/coordinates.mli
@@ -14,7 +14,7 @@ type element = { x : float; y : float; width : float; height : float }
 val get : Brr.El.t -> element
 
 module Window_of_elem : sig
-  val focus : element -> window
+  val focus : current:window -> element list -> window
   val enter : element -> window
   val up : ?margin:float -> current:window -> element -> window
   val center : current:window -> element -> window

--- a/src/engine/universe/window.ml
+++ b/src/engine/universe/window.ml
@@ -94,9 +94,10 @@ let move_relative ?(x = 0.) ?(y = 0.) ?(scale = 1.) window ~delay =
 let move_relative_pure ?(x = 0.) ?(y = 0.) ?(scale = 1.) window ~delay =
   move_relative ~x ~y ~scale window ~delay |> Undoable.discard
 
-let focus window elem =
-  let coords_e = Coordinates.get elem in
-  let coords_w = Coordinates.Window_of_elem.focus coords_e in
+let focus window elems =
+  let coords_e = List.map Coordinates.get elems in
+  let current = State.get_coord () in
+  let coords_w = Coordinates.Window_of_elem.focus ~current coords_e in
   move window coords_w ~delay:1.
 
 let focus_pure window elem = focus window elem |> Undoable.discard

--- a/src/engine/universe/window.mli
+++ b/src/engine/universe/window.mli
@@ -17,8 +17,8 @@ val move_relative :
   delay:float ->
   unit Undoable.t
 
-val focus_pure : window -> Brr.El.t -> unit Fut.t
-val focus : window -> Brr.El.t -> unit Undoable.t
+val focus_pure : window -> Brr.El.t list -> unit Fut.t
+val focus : window -> Brr.El.t list -> unit Undoable.t
 val enter : window -> Brr.El.t -> unit Undoable.t
 val up : window -> Brr.El.t -> unit Undoable.t
 val center : window -> Brr.El.t -> unit Undoable.t

--- a/test/engine/basic.t/new_engine.md
+++ b/test/engine/basic.t/new_engine.md
@@ -1,7 +1,7 @@
 Salut !
 
 {#a .unstatic}
-a
+[a]{#box1}
 
 {#b .unstatic}
 b
@@ -27,7 +27,7 @@ Three
 ## Title 1
 
 {pause #lehaut}
-Lorem ipsum dolor sit amet, consectetuer adipiscing elit.  Donec hendrerit tempor tellus.  Donec pretium posuere tellus.  Proin quam nisl, tincidunt et, mattis eget, convallis nec, purus.  Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.  Nulla posuere.  Donec vitae dolor.  Nullam tristique diam non turpis.  Cras placerat accumsan nulla.  Nullam rutrum.  Nam vestibulum accumsan nisl.
+Lorem ipsum [dolor]{#box2} sit amet, consectetuer adipiscing elit.  Donec hendrerit tempor tellus.  Donec pretium posuere tellus.  Proin quam nisl, tincidunt et, mattis eget, convallis nec, purus.  Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.  Nulla posuere.  Donec vitae dolor.  Nullam tristique diam non turpis.  Cras placerat accumsan nulla.  Nullam rutrum.  Nam vestibulum accumsan nisl.
 
 {pause exec-at-unpause}
 ```slip-script
@@ -41,7 +41,7 @@ return undo;
 - deuxième {pause} point
 - troisième
 
-{pause focus-at-unpause}
+{pause focus-at-unpause="box1 box2"}
 Lorem ipsum dolor sit amet, consectetuer adipiscing elit.  Donec hendrerit tempor tellus.  Donec pretium posuere tellus.  Proin quam nisl, tincidunt et, mattis eget, convallis nec, purus.  Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.  Nulla posuere.  Donec vitae dolor.  Nullam tristique diam non turpis.  Cras placerat accumsan nulla.  Nullam rutrum.  Nam vestibulum accumsan nisl.
 
 ## Title 3


### PR DESCRIPTION
First step for the first step of #99: you can provide multiple space-separated ids in `focus-at-unpause`.

(First second step is to add `slip.focus`. Second first step is to let user go wild and expose the coordinate type etc)