### PR TITLE
Access everything without gesture on mobile

### DIFF
--- a/src/compiler/lib/slipshow.ml
+++ b/src/compiler/lib/slipshow.ml
@@ -64,6 +64,11 @@ let embed_in_page content ~has_math ~math_link ~slip_css_link ~slipshow_js_link
           </div>
         </div>
       </div>
+      <div id="slip-touch-controls">
+        <div class="slip-previous">←</div>
+        <div class="slip-fullscreen">⇱</div>
+        <div class="slip-next">→</div>
+      </div>
       <div id="slipshow-counter">0</div>
     </div>
 

--- a/src/engine/drawing/drawing.css
+++ b/src/engine/drawing/drawing.css
@@ -12,7 +12,8 @@
 .slip-writing-toolbar:hover,
 .slipshow-drawing-mode .slip-writing-toolbar {
   width: 32px;
-  height: 640px;
+  height: min(640px, 100vh);
+  overflow: scroll;
 }
 .slip-writing-toolbar {
   background-color: white;

--- a/src/engine/normalization/normalization.css
+++ b/src/engine/normalization/normalization.css
@@ -5,6 +5,7 @@ body {
   bottom: 0;
   right: 0;
   display: flex;
+  flex-direction: row-reverse;
 }
 
 #slipshow-main {

--- a/src/engine/normalization/normalization.ml
+++ b/src/engine/normalization/normalization.ml
@@ -36,7 +36,12 @@ let replace_open_window window =
   let browser_h = foi @@ Brr.El.offset_h parent in
   let browser_w = foi @@ Brr.El.offset_w parent in
   let* window_w, _window_h =
+    let body = Brr.Document.body Brr.G.document in
     if width *. browser_h < height *. browser_w then
+      let () =
+        Brr.El.set_class (Jstr.v "horizontal") false body;
+        Brr.El.set_class (Jstr.v "vertical") true body
+      in
       let window_w = browser_h *. width /. height in
       let window_h = browser_h in
       let+ () =
@@ -47,6 +52,10 @@ let replace_open_window window =
       in
       (window_w, window_h)
     else
+      let () =
+        Brr.El.set_class (Jstr.v "horizontal") true body;
+        Brr.El.set_class (Jstr.v "vertical") false body
+      in
       let window_h = browser_w *. height /. width in
       let window_w = browser_w in
       let+ () =

--- a/src/engine/step/step.css
+++ b/src/engine/step/step.css
@@ -21,4 +21,8 @@
   right: 0;
   background-color: white;
   padding: 5px;
+  font-size: 2em;
+  border: 1px solid black;
+  border-radius: 5px;
+  cursor: pointer;
 }

--- a/src/engine/table_of_content/table_of_content.ml
+++ b/src/engine/table_of_content/table_of_content.ml
@@ -67,6 +67,11 @@ let categorize window step el =
   let el = entry window step ~tag_name ~content in
   (el, step)
 
+let toggle_visibility () =
+  let body = Brr.Document.body Brr.G.document in
+  let c = Jstr.v "slipshow-toc-mode" in
+  Brr.El.set_class c (not @@ Brr.El.class' c body) body
+
 let generate window root =
   let els =
     Brr.El.fold_find_by_selector ~root
@@ -80,4 +85,11 @@ let generate window root =
   in
   let els = entry window (Some 0) ~tag_name:!!"div" ~content:!!"" :: els in
   let toc_el = Brr.El.div ~at:[ Brr.At.id !!"slipshow-toc" ] els in
-  Brr.El.append_children (Brr.Document.body Brr.G.document) [ toc_el ]
+  Brr.El.append_children (Brr.Document.body Brr.G.document) [ toc_el ];
+  let _unlisten =
+    Brr.Ev.listen Brr.Ev.click
+      (fun _ -> toggle_visibility ())
+      (Brr.El.find_first_by_selector (Jstr.v "#slipshow-counter")
+      |> Option.get |> Brr.El.as_target)
+  in
+  ()

--- a/src/engine/table_of_content/table_of_content.mli
+++ b/src/engine/table_of_content/table_of_content.mli
@@ -1,1 +1,2 @@
 val generate : Universe.Window.window -> Brr.El.t -> unit
+val toggle_visibility : unit -> unit

--- a/src/engine/themes/default.css
+++ b/src/engine/themes/default.css
@@ -16,7 +16,7 @@ h1:not(#slipshow-toc h1) {
   text-align: center;
 }
 
-body {
+body.slipshow-drawing-mode {
   touch-action: pinch-zoom;
 }
 
@@ -204,4 +204,58 @@ body {
 }
 .corollary[title]:before {
   content: "Corollary (" attr(title) ") ";
+}
+
+#slip-touch-controls {
+  display: none;
+}
+
+.mobile #slip-touch-controls {
+  display: unset;
+}
+
+.mobile.slipshow-toc-mode.horizontal #slip-touch-controls,
+.mobile.slipshow-toc-mode.vertical #slip-touch-controls {
+  display: none;
+}
+
+.mobile.horizontal #slip-touch-controls {
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+  display: flex;
+  height: 10vw;
+  justify-content: space-evenly;
+}
+
+.mobile.horizontal #slip-touch-controls > div {
+  width: 10vw;
+  background: rgba(0, 0, 0, 0.3);
+  cursor: pointer;
+  color: white;
+  font-size: 10vw;
+  text-align: center;
+  vertical-align: middle;
+  line-height: 10vw;
+}
+
+.mobile.vertical #slip-touch-controls {
+  position: fixed;
+  right: 0;
+  width: 10vh;
+  display: flex;
+  height: 80vh;
+  justify-content: space-evenly;
+  flex-direction: column;
+}
+
+.mobile.vertical #slip-touch-controls > div {
+  width: 10vh;
+  background: rgba(0, 0, 0, 0.3);
+  cursor: pointer;
+  color: white;
+  font-size: 10vh;
+  text-align: center;
+  vertical-align: middle;
+  line-height: 10vh;
 }


### PR DESCRIPTION
Previously, mobile navigation was made using gestures, but that conflicted with "native" gesture for eg refreshing, going back, ...

This PR makes everything navigable with buttons and click listeners. The CSS is horrible and needs fixing, but that is already better than before.