### PR TITLE
Group CLI into subcommands for different usecases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### CLI
+
+- Split commands in groups (#112). Examples:
+  - `slipshow file.md` becomes `slipshow compile file.md`
+  - `slipshow --serve file.md` becomes `slipshow serve file.md`
+  - `slipshow --markdown-output file.md` becomes `slipshow markdown file.md`
+
+### Engine
+
 - Allow to focus on multiple elements. Zooms as much as possible so everything
   is visible, and center. Backward compatible, focusing on a single
   element. (#103)

--- a/src/cli/main.ml
+++ b/src/cli/main.ml
@@ -9,29 +9,22 @@ let setup_log style_renderer level =
 let setup_log =
   Term.(const setup_log $ Fmt_cli.style_renderer () $ Logs_cli.level ())
 
-let compile =
-  let compile input output math_link slip_css_link slipshow_js_link watch serve
-      markdown_mode () =
-    let input = match input with "-" -> `Stdin | s -> `File (Fpath.v s) in
-    let output_of_input input =
-      match (input, markdown_mode) with
-      | `File input, false -> `File (Fpath.set_ext "html" input)
-      | `File input, true -> `File (Fpath.set_ext "noattrs.md" input)
-      | `Stdin, _ -> `Stdout
+module Conv = struct
+  let io std =
+    let parser_ s =
+      match s with "-" -> Ok std | s -> Ok (`File (Fpath.v s))
     in
-    let output =
-      match output with
-      | Some "-" -> `Stdout
-      | Some output -> `File (Fpath.v output)
-      | None -> output_of_input input
+    let printer fmt = function
+      | `File s -> Format.fprintf fmt "%a" Fpath.pp s
+      | _ -> Format.fprintf fmt "-"
     in
-    match
-      Run.go ~input ~output ~math_link ~slip_css_link ~slipshow_js_link ~watch
-        ~serve ~markdown_mode
-    with
-    | Ok () -> Ok ()
-    | Error (`Msg s) -> Error s
-  in
+    Arg.conv (parser_, printer)
+
+  let input = io `Stdin
+  let output = io `Stdout
+end
+
+module Common_args = struct
   let math_link =
     let doc =
       "Where to find the mathjax javascript file. Optional. When absent, use \
@@ -40,70 +33,142 @@ let compile =
     in
     Arg.(
       value & opt (some string) None & info ~docv:"URL" ~doc [ "m"; "mathjax" ])
-  in
-  let slipshow_js_link =
-    let doc =
-      "Where to find the slipshow javascript file. Optional. When absent, use \
-       slipshow.%%VERSION%%, embedded in this binary. If URL is an absolute \
-       URL, links to it, otherwise the content is embedded in the html file."
-    in
-    Arg.(value & opt (some string) None & info ~docv:"URL" ~doc [ "slipshow" ])
-  in
-  let slip_css_link =
-    let doc =
-      "Where to find the slipshow css file. Optional. When absent, use \
-       slipshow.%%VERSION%%, embedded in this binary. If URL is an absolute \
-       URL, links to it, otherwise the content is embedded in the html file."
-    in
-    Arg.(value & opt (some string) None & info ~docv:"URL" ~doc [ "slip-css" ])
-  in
+
   let output =
     let doc =
       "Output file path. When absent, generate a filename based on the input \
        name."
     in
     Arg.(
-      value & opt (some string) None & info ~docv:"PATH" ~doc [ "o"; "output" ])
-  in
+      value
+      & opt (some Conv.output) None
+      & info ~docv:"PATH" ~doc [ "o"; "output" ])
+
   let input =
     let doc =
       "$(docv) is the CommonMark file to process. Reads from $(b,stdin) if \
        $(b,-) is specified."
     in
-    Arg.(value & pos 0 string "-" & info [] ~doc ~docv:"FILE.md")
-  in
-  let markdown_output =
-    let doc =
-      "Outputs a markdown file with valid (GFM) syntax, by stripping the \
-       attributes. Useful for printing for instance."
-    in
-    Arg.(value & flag & info [ "markdown-output" ] ~doc ~docv:"FILE.md")
-  in
+
+    Arg.(value & pos 0 Conv.input `Stdin & info [] ~doc ~docv:"FILE.md")
+end
+
+module Compile = struct
   let watch =
-    let doc = "Watch" in
-    Arg.(value & flag & info [ "watch" ] ~doc ~docv:"")
-  in
-  let serve =
-    let doc = "Serve" in
-    Arg.(value & flag & info [ "serve" ] ~doc ~docv:"")
-  in
-  Term.(
-    const compile $ input $ output $ math_link $ slip_css_link
-    $ slipshow_js_link $ watch $ serve $ markdown_output $ setup_log)
+    let doc = "Watch the input file, and recompile when changes happen." in
+    Arg.(value & flag & info ~docv:"" ~doc [ "watch" ])
 
-let compile_cmd =
-  let doc = "Compile a markdown file into a slipshow presentation" in
+  let ( let* ) = Result.bind
+
+  let output_of_input = function
+    | `File input -> `File (Fpath.set_ext "html" input)
+    | `Stdin -> `Stdout
+
+  let force_file_io input output =
+    let* input =
+      match input with
+      | `File input -> Ok input
+      | `Stdin -> Error "Standard input cannot be used in serve nor watch mode"
+    in
+    match output with
+    | `File o -> Ok (input, o)
+    | `Stdout -> Error "Standard output cannot be used in serve nor watch mode"
+
+  let compile ~watch ~input ~output ~math_link =
+    let output =
+      match output with Some o -> o | None -> output_of_input input
+    in
+    if watch then
+      let* input, output = force_file_io input output in
+      Run.watch ~input ~output ~math_link
+      |> Result.map_error @@ fun (`Msg s) -> s
+    else
+      Run.compile ~input ~output ~math_link
+      |> Result.map_error @@ fun (`Msg s) -> s
+
+  let term =
+    let open Common_args in
+    let open Term.Syntax in
+    let+ input = input
+    and+ output = output
+    and+ math_link = math_link
+    and+ watch = watch
+    and+ () = setup_log in
+    compile ~input ~output ~math_link ~watch
+
+  let cmd =
+    let doc =
+      "Compile a slipshow source file into a slipshow html presentation"
+    in
+    let man = [] in
+    let info = Cmd.info "compile" ~version:"%%VERSION%%" ~doc ~man in
+    Cmd.v info term
+end
+
+module Serve = struct
+  let ( let* ) = Result.bind
+
+  let serve ~input ~output ~math_link =
+    let output =
+      match output with Some o -> o | None -> Compile.output_of_input input
+    in
+    let* input, output = Compile.force_file_io input output in
+    match Run.serve ~input ~output ~math_link with
+    | Ok () -> Ok ()
+    | Error (`Msg s) -> Error s
+
+  let term =
+    let open Common_args in
+    let open Term.Syntax in
+    let+ input = input
+    and+ output = output
+    and+ math_link = math_link
+    and+ () = setup_log in
+    serve ~input ~output ~math_link
+
+  let cmd =
+    let doc =
+      "Serve a live preview of a slipshow presentation, with hot-reloading"
+    in
+    let man = [] in
+    let info = Cmd.info "serve" ~version:"%%VERSION%%" ~doc ~man in
+    Cmd.v info term
+end
+
+module Markdownify = struct
+  let do_ ~input ~output =
+    let output_of_input = function
+      | `File input -> `File (Fpath.set_ext "noattrs.md" input)
+      | `Stdin -> `Stdout
+    in
+    let output =
+      match output with Some o -> o | None -> output_of_input input
+    in
+    match Run.markdown_compile ~input ~output with
+    | Ok () -> Ok ()
+    | Error (`Msg s) -> Error s
+
+  let term =
+    let open Common_args in
+    let open Term.Syntax in
+    let+ input = input and+ output = output and+ () = setup_log in
+    do_ ~input ~output
+
+  let cmd =
+    let doc =
+      "Compile a slipshow source into a pure Markdown file, effectively \
+       removing presentation attributes"
+    in
+    let man = [] in
+    let info = Cmd.info "markdown" ~version:"%%VERSION%%" ~doc ~man in
+    Cmd.v info term
+end
+
+let group =
+  let doc = "A tool to compile and preview slipshow presentation" in
   let man = [] in
-  let info = Cmd.info "compile" ~version:"%%VERSION%%" ~doc ~man in
-  Cmd.v info compile
+  let info = Cmd.info "slipshow" ~version:"%%VERSION%%" ~doc ~man in
+  Cmd.group info [ Compile.cmd; Serve.cmd; Markdownify.cmd ]
 
-(* Currently, it seems to not possible to have positioned arguments for a default group command.
-   Would have been good!
-
-   let doc = "Compile a markdown file into a slipshow presentation" in
-   let man = [] in
-   let info = Cmd.info "slip_of_mark" ~version:"%%VERSION%%" ~doc ~man in
-   Cmd.group ~default:compile info [ compile_cmd ] *)
-let cmd = compile_cmd
-let main () = exit (Cmd.eval_result cmd)
+let main () = exit (Cmd.eval_result group)
 let () = main ()

--- a/src/cli/run.mli
+++ b/src/cli/run.mli
@@ -1,10 +1,22 @@
-val go :
-  markdown_mode:bool ->
-  math_link:string option ->
-  slip_css_link:string option ->
-  slipshow_js_link:string option ->
+val compile :
   input:[< `File of Fpath.t | `Stdin ] ->
   output:[< `File of Fpath.t | `Stdout ] ->
-  watch:bool ->
-  serve:bool ->
+  math_link:string option ->
+  (unit, [ `Msg of string ]) result
+
+val watch :
+  input:Fpath.t ->
+  output:Fpath.t ->
+  math_link:string option ->
+  (unit, [ `Msg of string ]) result
+
+val serve :
+  input:Fpath.t ->
+  output:Fpath.t ->
+  math_link:string option ->
+  (unit, [ `Msg of string ]) result
+
+val markdown_compile :
+  input:[< `File of Fpath.t | `Stdin ] ->
+  output:[< `File of Fpath.t | `Stdout ] ->
   (unit, [ `Msg of string ]) result

--- a/src/server/slipshow_server.mli
+++ b/src/server/slipshow_server.mli
@@ -5,5 +5,5 @@ val do_serve :
 
 val do_watch :
   [< `File of Fpath.t | `Stdin ] ->
-  (unit -> (string, [ `Msg of string ]) result) ->
+  (unit -> (unit, [ `Msg of string ]) result) ->
   (unit, [ `Msg of string ]) result

--- a/test/compiler/simple.t/run.t
+++ b/test/compiler/simple.t/run.t
@@ -1,6 +1,6 @@
 We can compile the file using the slip_of_mark binary
 
-  $ slipshow -o file.html file.md
+  $ slipshow compile -o file.html file.md
 
   $ cat file.html | grep "<body>" -A 10
     <body>
@@ -20,20 +20,20 @@ $ du -h file.html
 
 What happens if the file does not exists? There is an error message...
 
-  $ slipshow -o file.html non-existing-file.md
-  compile: non-existing-file.md: No such file or directory
+  $ slipshow compile -o file.html non-existing-file.md
+  slipshow: non-existing-file.md: No such file or directory
   [123]
 
 If we do not pass an output file, it is infer the output name from the input name
 
   $ cp file.md blibli.md
-  $ slipshow blibli.md
+  $ slipshow compile blibli.md
   $ ls blibli.html
   blibli.html
 
 If we do not pass an input file, it gets its value from stdin
 
-  $ slipshow -o file.html << EOF
+  $ slipshow compile -o file.html << EOF
   > # Title
   > 
   > Paragraph
@@ -56,7 +56,7 @@ If we give neither the input nor the output, stdin and stdout are used:
 
 If we do not pass an input file, it gets its value from stdin
 
-  $ slipshow > stdout.html << EOF
+  $ slipshow compile > stdout.html << EOF
   > # Title
   > 
   > Paragraph
@@ -75,9 +75,9 @@ If we pass a mathjax value, with a remote url:
   > EOF
   $ echo "#title 1+1=0" > without_math.md
 
-  $ slipshow -o m1.html --mathjax https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js with_inline_math.md
-  $ slipshow -o m2.html --mathjax https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js with_block_math.md
-  $ slipshow -o m3.html --mathjax https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js without_math.md
+  $ slipshow compile -o m1.html --mathjax https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js with_inline_math.md
+  $ slipshow compile -o m2.html --mathjax https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js with_block_math.md
+  $ slipshow compile -o m3.html --mathjax https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js without_math.md
 
   $ cat m1.html | grep mathjax
       <script id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
@@ -89,15 +89,15 @@ If we pass a mathjax value, with a remote url:
 With a file
 
   $ echo "dummyABC" > mathjax.js
-  $ slipshow -o m.html --mathjax mathjax-unknown.js with_inline_math.md
+  $ slipshow compile -o m.html --mathjax mathjax-unknown.js with_inline_math.md
   slipshow: [WARNING] Could not read file: mathjax-unknown.js. Considering it as an URL. (mathjax-unknown.js: No such file or directory)
-  $ slipshow -o m.html --mathjax mathjax.js with_inline_math.md
+  $ slipshow compile -o m.html --mathjax mathjax.js with_inline_math.md
   $ cat m.html | grep -A 1 dummyABC
       <script id="MathJax-script">dummyABC
   </script>
 
 Images
 
-  $ slipshow file_with_image.md
+  $ slipshow compile file_with_image.md
   $ cat file_with_image.html | grep image | grep base64
                 <p><span>A paragraph with an </span><img src="data:;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAIAAAACUFjqAAABg2lDQ1BJQ0MgcHJvZmlsZQAAKJF9kT1Iw0AcxV9bpaIVB4OIOGSoTnZREcdahSJUCLVCqw4ml35Bk4YkxcVRcC04+LFYdXBx1tXBVRAEP0BcXZwUXaTE/yWFFjEeHPfj3b3H3Tsg2KgwzeqKA5pum+lkQszmVsXwK/ogIIIhCDKzjDlJSsF3fN0jwNe7GM/yP/fn6FfzFgMCInGcGaZNvEE8s2kbnPeJBVaSVeJz4gmTLkj8yHXF4zfORZeDPFMwM+l5YoFYLHaw0sGsZGrE08RRVdMpP5j1WOW8xVmr1FjrnvyFkby+ssx1mqNIYhFLkCBCQQ1lVGAjRqtOioU07Sd8/COuXyKXQq4yGDkWUIUG2fWD/8Hvbq3C1KSXFEkA3S+O8zEGhHeBZt1xvo8dp3kChJ6BK73trzaA2U/S620tegQMbAMX121N2QMud4DhJ0M2ZVcK0QwWCsD7GX1TDhi8BXrXvN5a+zh9ADLUVeoGODgExouUve7z7p7O3v490+rvB2/RcqXOpP/kAAAACXBIWXMAAC4jAAAuIwF4pT92AAAAB3RJTUUH5wsUDBghqFYBIAAAABl0RVh0Q29tbWVudABDcmVhdGVkIHdpdGggR0lNUFeBDhcAAACeSURBVBjTbY4xCoQwFEQny1aWCVFPkEKTK4SAeATv5wE8gjew+wpewV/aB9xC1Cz4qhkeDIPjYhzHruuGYTgScCciUkp571P9wYVzLsYopUTCd55nAHmen31dV2YuigIAM6OqKmPM6YQQAO4KQEzTtO87AGttWZZZlvV9T0QhhKZpnmvbthlj6rp+v/bKo5dlYea2bf98Oq61JqJ0/AfIKIeErZAqOwAAAABJRU5ErkJggg==" alt="image" ></p>

--- a/test/compiler/to_commonmark.t/run.t
+++ b/test/compiler/to_commonmark.t/run.t
@@ -1,6 +1,6 @@
 We can compile the file using the slip_of_mark binary
 
-  $ slipshow --markdown-output file.md
+  $ slipshow markdown file.md
 
   $ cat file.noattrs.md
   # A title

--- a/test/engine/basic.t/run.t
+++ b/test/engine/basic.t/run.t
@@ -1,5 +1,5 @@
 
 
-  $ slipshow new_engine.md
+  $ slipshow compile new_engine.md
 $ cp new_engine.html /tmp/
 

--- a/test/engine/campus_du_libre.t/run.t
+++ b/test/engine/campus_du_libre.t/run.t
@@ -1,5 +1,5 @@
 
 
-  $ slipshow cdl.md
+  $ slipshow compile cdl.md
 $ cp cdl.html /tmp/
 


### PR DESCRIPTION
Allows to separate the options for `serve` from those from `compile`, and similarly for `markdown`.

Also, removes the option to specify the engine files to use. Later, we'll introduce a better way to do this.

- Good thing:
  Man pages are clearer, and it's by design impossible to use incompatible commands such as:
   ```console
   $ slipshow --mathjax bli --markdown-output file.md
   ```
   (Specifying mathjax file for a markdown output does not make sense...)

  Extending the CLI will be much easier (eg add a `slipshow themes list/add/...` command)

- Bad thing:
CLI is slighty more complex for just compiling a file: `slipshow compile file.md` instead of `slipshow file.md`.