### PR TITLE
Fix wrong computed coordinates

### DIFF
--- a/src/engine/universe/coordinates.ml
+++ b/src/engine/universe/coordinates.ml
@@ -42,11 +42,13 @@ let get elem =
         let scale = compute_scale parent *. parent_scale in
         let x =
           cx +. (x *. scale)
-          +. (1. (* The (hardcoded) slip border *) *. parent_scale)
+          +. 0.5 (* The (hardcoded) slip border (divided by 2?) *)
+             *. parent_scale
         in
         let y =
           cy +. (y *. scale)
-          +. (1. (* The (hardcoded) slip border *) *. parent_scale)
+          +. 0.5 (* The (hardcoded) slip border (divided by 2?) *)
+             *. parent_scale
         in
         ((x, y), scale)
   in


### PR DESCRIPTION
Fix wrong computed coordinates, especially visible when you aggressively scale your slips.

(I'm not even sure why it works, but it does work.)