### PR TITLE
Allow to specify the dimension (in pixels) of the presentation

### DIFF
--- a/src/cli/run.ml
+++ b/src/cli/run.ml
@@ -34,7 +34,7 @@ let parse_theme to_asset theme =
   | Some theme -> `Builtin theme
   | None -> `External (to_asset theme)
 
-let compile ~dimension ~input ~output ~math_link ~css_links ~theme =
+let compile ~width ~height ~input ~output ~math_link ~css_links ~theme =
   let asset_files, to_asset =
     let used_files, read_file = read_file (Fpath.v "./") () in
     (used_files, Slipshow.Asset.of_string ~read_file)
@@ -49,7 +49,8 @@ let compile ~dimension ~input ~output ~math_link ~css_links ~theme =
       ()
   in
   let html =
-    Slipshow.convert ?dimension ?math_link ~css_links ?theme ~read_file content
+    Slipshow.convert ~width ~height ?math_link ~css_links ?theme ~read_file
+      content
   in
   let all_used_files = Fpath.Set.union !asset_files !used_files in
   match output with
@@ -65,15 +66,15 @@ let compile ~dimension ~input ~output ~math_link ~css_links ~theme =
             (Fpath.normalize (Fpath.( // ) (Fpath.v (Sys.getcwd ())) f))
             all_used_files)
 
-let watch ~dimension ~input ~output ~math_link ~css_links ~theme =
+let watch ~width ~height ~input ~output ~math_link ~css_links ~theme =
   let input = `File input and output = `File output in
   let compile () =
     Logs.app (fun m -> m "Compiling...");
-    compile ~input ~output ~math_link ~css_links ~theme ~dimension
+    compile ~input ~output ~math_link ~css_links ~theme ~width ~height
   in
   Slipshow_server.do_watch compile
 
-let serve ~dimension ~input ~output ~math_link ~css_links ~theme =
+let serve ~width ~height ~input ~output ~math_link ~css_links ~theme =
   let compile () =
     let asset_files, to_asset =
       let used_files, read_file = read_file (Fpath.v "./") () in
@@ -85,8 +86,8 @@ let serve ~dimension ~input ~output ~math_link ~css_links ~theme =
     let theme = Option.map (parse_theme to_asset) theme in
     let used_files, read_file = read_file (Fpath.parent input) () in
     let result =
-      Slipshow.delayed ?dimension ~css_links ?math_link:math_link_asset ?theme
-        ~read_file content
+      Slipshow.delayed ~width ~height ~css_links ?math_link:math_link_asset
+        ?theme ~read_file content
     in
     let all_used_files = Fpath.Set.union !asset_files !used_files in
     let html = Slipshow.add_starting_state result None in

--- a/src/cli/run.mli
+++ b/src/cli/run.mli
@@ -1,5 +1,6 @@
 val compile :
-  dimension:(int * int) option ->
+  width:int ->
+  height:int ->
   input:[ `File of Fpath.t | `Stdin ] ->
   output:[ `File of Fpath.t | `Stdout ] ->
   math_link:string option ->
@@ -8,7 +9,8 @@ val compile :
   (Fpath.Set.t, [ `Msg of string ]) result
 
 val watch :
-  dimension:(int * int) option ->
+  width:int ->
+  height:int ->
   input:Fpath.t ->
   output:Fpath.t ->
   math_link:string option ->
@@ -17,7 +19,8 @@ val watch :
   (unit, [ `Msg of string ]) result
 
 val serve :
-  dimension:(int * int) option ->
+  width:int ->
+  height:int ->
   input:Fpath.t ->
   output:Fpath.t ->
   math_link:string option ->

--- a/src/cli/run.mli
+++ b/src/cli/run.mli
@@ -1,4 +1,5 @@
 val compile :
+  dimension:(int * int) option ->
   input:[ `File of Fpath.t | `Stdin ] ->
   output:[ `File of Fpath.t | `Stdout ] ->
   math_link:string option ->
@@ -7,6 +8,7 @@ val compile :
   (Fpath.Set.t, [ `Msg of string ]) result
 
 val watch :
+  dimension:(int * int) option ->
   input:Fpath.t ->
   output:Fpath.t ->
   math_link:string option ->
@@ -15,6 +17,7 @@ val watch :
   (unit, [ `Msg of string ]) result
 
 val serve :
+  dimension:(int * int) option ->
   input:Fpath.t ->
   output:Fpath.t ->
   math_link:string option ->

--- a/src/compiler/slipshow.ml
+++ b/src/compiler/slipshow.ml
@@ -129,9 +129,8 @@ let convert_to_md ~read_file content =
   let sd = Compile.to_cmarkit sd in
   Cmarkit_commonmark.of_doc ~include_attributes:false sd
 
-let delayed ?(dimension = (1440, 1080)) ?math_link ?(css_links = [])
+let delayed ~width ~height ?math_link ?(css_links = [])
     ?(theme = `Builtin Themes.Default) ?slipshow_js_link ?read_file s =
-  let width, height = dimension in
   let md = Compile.compile ?read_file s in
   let content =
     Cmarkit_renderer.doc_to_string Renderers.custom_html_renderer md
@@ -148,10 +147,10 @@ let add_starting_state (start, end_) starting_state =
   in
   start ^ starting_state ^ end_
 
-let convert ?dimension ?starting_state ?math_link ?theme ?css_links
+let convert ~width ~height ?starting_state ?math_link ?theme ?css_links
     ?slipshow_js_link ?(read_file = fun _ -> Ok None) s =
   let delayed =
-    delayed ?math_link ?css_links ?theme ?slipshow_js_link ?dimension ~read_file
-      s
+    delayed ?math_link ?css_links ?theme ?slipshow_js_link ~width ~height
+      ~read_file s
   in
   add_starting_state delayed starting_state

--- a/src/compiler/slipshow.mli
+++ b/src/compiler/slipshow.mli
@@ -27,7 +27,8 @@ val delayed_to_string : delayed -> string
 val string_to_delayed : string -> delayed
 
 val delayed :
-  ?dimension:int * int ->
+  width:int ->
+  height:int ->
   ?math_link:Asset.t ->
   ?css_links:Asset.t list ->
   ?theme:[ `Builtin of Themes.t | `External of Asset.t ] ->
@@ -42,7 +43,8 @@ val delayed :
 val add_starting_state : delayed -> starting_state option -> string
 
 val convert :
-  ?dimension:int * int ->
+  width:int ->
+  height:int ->
   ?starting_state:starting_state ->
   ?math_link:Asset.t ->
   ?theme:[ `Builtin of Themes.t | `External of Asset.t ] ->

--- a/src/compiler/slipshow.mli
+++ b/src/compiler/slipshow.mli
@@ -27,6 +27,7 @@ val delayed_to_string : delayed -> string
 val string_to_delayed : string -> delayed
 
 val delayed :
+  ?dimension:int * int ->
   ?math_link:Asset.t ->
   ?css_links:Asset.t list ->
   ?theme:[ `Builtin of Themes.t | `External of Asset.t ] ->
@@ -41,6 +42,7 @@ val delayed :
 val add_starting_state : delayed -> starting_state option -> string
 
 val convert :
+  ?dimension:int * int ->
   ?starting_state:starting_state ->
   ?math_link:Asset.t ->
   ?theme:[ `Builtin of Themes.t | `External of Asset.t ] ->

--- a/src/engine/constants/constants.ml
+++ b/src/engine/constants/constants.ml
@@ -1,2 +1,6 @@
-let width = 1440.
-let height = 1080.
+let width = ref 1440.
+let height = ref 1080.
+let set_width = ( := ) width
+let set_height = ( := ) height
+let width () = !width
+let height () = !height

--- a/src/engine/constants/constants.mli
+++ b/src/engine/constants/constants.mli
@@ -1,2 +1,4 @@
-val width : float
-val height : float
+val set_width : float -> unit
+val set_height : float -> unit
+val width : unit -> float
+val height : unit -> float

--- a/src/engine/main.ml
+++ b/src/engine/main.ml
@@ -1,4 +1,6 @@
-let start id step =
+let start ~width ~height ~id ~step =
+  Constants.set_height height;
+  Constants.set_width width;
   let open Fut.Syntax in
   let el =
     Brr.El.find_first_by_selector (Jstr.v "#slipshow-content") |> Option.get
@@ -39,7 +41,11 @@ let start id step =
   Fut.return ()
 
 let () =
-  let start step id =
-    start (Jv.to_option Jv.to_string id) (Jv.to_option Jv.to_int step)
+  let start width height step id =
+    let height = Jv.to_float height in
+    let width = Jv.to_float width in
+    let id = Jv.to_option Jv.to_string id in
+    let step = Jv.to_option Jv.to_int step in
+    start ~width ~height ~id ~step
   in
-  Jv.set Jv.global "startSlipshow" (Jv.callback ~arity:2 start)
+  Jv.set Jv.global "startSlipshow" (Jv.callback ~arity:4 start)

--- a/src/engine/normalization/dune
+++ b/src/engine/normalization/dune
@@ -1,3 +1,3 @@
 (library
  (name normalization)
- (libraries brr browser))
+ (libraries brr browser constants))

--- a/src/engine/normalization/normalization.ml
+++ b/src/engine/normalization/normalization.ml
@@ -1,9 +1,7 @@
 open Brr
 open Fut.Syntax
 module Window = Brr.Window
-
-let width = 1440.
-let height = 1080.
+open Constants
 
 type t = { open_window : El.t; format_container : El.t }
 type state = { left : float; top : float; scale : float }
@@ -13,7 +11,7 @@ let state = ref { left = 0.; top = 0.; scale = 1. }
 let translate_coords (x, y) =
   let x = (x -. !state.left) /. !state.scale
   and y = (y -. !state.top) /. !state.scale in
-  let x = x -. (width /. 2.) and y = y -. (height /. 2.) in
+  let x = x -. (width () /. 2.) and y = y -. (height () /. 2.) in
   (x, y)
 
 let replace_open_window window =
@@ -37,12 +35,12 @@ let replace_open_window window =
   let browser_w = foi @@ Brr.El.offset_w parent in
   let* window_w, _window_h =
     let body = Brr.Document.body Brr.G.document in
-    if width *. browser_h < height *. browser_w then
+    if width () *. browser_h < height () *. browser_w then
       let () =
         Brr.El.set_class (Jstr.v "horizontal") false body;
         Brr.El.set_class (Jstr.v "vertical") true body
       in
-      let window_w = browser_h *. width /. height in
+      let window_w = browser_h *. width () /. height () in
       let window_h = browser_h in
       let+ () =
         set_state
@@ -56,7 +54,7 @@ let replace_open_window window =
         Brr.El.set_class (Jstr.v "horizontal") true body;
         Brr.El.set_class (Jstr.v "vertical") false body
       in
-      let window_h = browser_w *. height /. width in
+      let window_h = browser_w *. height () /. width () in
       let window_w = browser_w in
       let+ () =
         set_state
@@ -66,8 +64,8 @@ let replace_open_window window =
       in
       (window_w, window_h)
   in
-  state := { !state with scale = window_w /. width };
-  Browser.Css.set [ Scale (window_w /. width) ] window.format_container
+  state := { !state with scale = window_w /. width () };
+  Browser.Css.set [ Scale (window_w /. width ()) ] window.format_container
 
 let create el =
   let format_container =

--- a/src/engine/rescale/rescale.css
+++ b/src/engine/rescale/rescale.css
@@ -1,13 +1,13 @@
 .slip, .slide {
-  width: calc(1440px - 2px);
+  width: calc(var(--page-width) - 2px);
   transform-origin: top left;
   /* Borders make margin of inner elements not leak outside */
   border: 1px solid transparent;
 }
 
 .slide {
-  height: calc(1080px - 2px);
-  width: calc(1440px - 2px);
+  height: calc(var(--page-height) - 2px);
+  width: calc(var(--page-width) - 2px);
 }
 
 .slipshow-rescaler {

--- a/src/engine/rescale/rescale.css
+++ b/src/engine/rescale/rescale.css
@@ -1,13 +1,13 @@
 .slip, .slide {
-  width: 1438px;
+  width: calc(1440px - 2px);
   transform-origin: top left;
   /* Borders make margin of inner elements not leak outside */
   border: 1px solid transparent;
 }
 
 .slide {
-    height: calc(1080px - 2px);
-    width: calc(1440px - 2px);
+  height: calc(1080px - 2px);
+  width: calc(1440px - 2px);
 }
 
 .slipshow-rescaler {

--- a/src/engine/universe/coord_computation.ml
+++ b/src/engine/universe/coord_computation.ml
@@ -52,26 +52,31 @@ module Window = struct
     | [] -> current
     | elem :: elems ->
         let box = List.fold_left box elem elems in
-        let scale1 = width /. box.width and scale2 = height /. box.height in
+        let scale1 = width () /. box.width
+        and scale2 = height () /. box.height in
         let scale = Float.min scale1 scale2 in
         { scale; x = box.x; y = box.y }
 
   let enter elem =
-    let scale = width /. elem.width in
-    let y = elem.y -. (elem.height /. 2.) +. (height /. 2. /. scale) in
+    let scale = width () /. elem.width in
+    let y = elem.y -. (elem.height /. 2.) +. (height () /. 2. /. scale) in
     { scale; x = elem.x; y }
 
   let up ?(margin = 13.5) ~current elem =
     let margin = margin /. current.scale in
     let y =
-      elem.y -. (elem.height /. 2.) +. (height /. 2. /. current.scale) -. margin
+      elem.y -. (elem.height /. 2.)
+      +. (height () /. 2. /. current.scale)
+      -. margin
     in
     { current with y }
 
   let down ?(margin = 13.5) ~current elem =
     let margin = margin /. current.scale in
     let y =
-      elem.y +. (elem.height /. 2.) -. (height /. 2. /. current.scale) +. margin
+      elem.y +. (elem.height /. 2.)
+      -. (height () /. 2. /. current.scale)
+      +. margin
     in
     { current with y }
 

--- a/src/engine/universe/move.ml
+++ b/src/engine/universe/move.ml
@@ -72,10 +72,10 @@ let scroll window elem =
   let current = State.get_coord () in
   if
     coords_e.y -. (coords_e.height /. 2.)
-    < current.y -. (Constants.height /. 2. *. current.scale)
+    < current.y -. (Constants.height () /. 2. *. current.scale)
   then up window elem
   else if
     coords_e.y +. (coords_e.height /. 2.)
-    > current.y +. (Constants.height /. 2. *. current.scale)
+    > current.y +. (Constants.height () /. 2. *. current.scale)
   then down window elem
   else Undoable.return ()

--- a/src/engine/universe/state.ml
+++ b/src/engine/universe/state.ml
@@ -1,7 +1,7 @@
 open Constants
 
 let coordinates =
-  ref { Coordinates.x = width /. 2.; y = height /. 2.; scale = 1. }
+  ref { Coordinates.x = width () /. 2.; y = height () /. 2.; scale = 1. }
 
 let set_coord v = coordinates := v
 let get_coord () = !coordinates

--- a/src/engine/universe/window.ml
+++ b/src/engine/universe/window.ml
@@ -75,7 +75,9 @@ let setup el =
   in
   Brr.El.insert_siblings `Replace el [ rotate_container ];
   Brr.El.append_children universe [ el ];
-  let+ () = Browser.Css.set [ Width width; Height height ] scale_container in
+  let+ () =
+    Browser.Css.set [ Width (width ()); Height (height ()) ] scale_container
+  in
   { rotate_container; scale_container; universe }
 
 let fast_move = ref false
@@ -130,8 +132,8 @@ let move_pure window ({ x; y; scale } as target : Coordinates.window) ~delay =
           (TransitionTiming "", TransitionDelay 0.) )
   in
   State.set_coord target;
-  let x = -.x +. (width /. 2.) in
-  let y = -.y +. (height /. 2.) in
+  let x = -.x +. (width () /. 2.) in
+  let y = -.y +. (height () /. 2.) in
   let+ () = Browser.Css.set [ TransitionDuration delay ] window.scale_container
   and+ () = Browser.Css.set [ scale_function ] window.scale_container
   and+ () = Browser.Css.set [ scale_delay ] window.scale_container

--- a/src/previewer/previewer.ml
+++ b/src/previewer/previewer.ml
@@ -53,7 +53,8 @@ let preview { stage; index; panels } source =
     Jv.set (Brr.El.to_jv panels.(unused ())) "srcdoc" (Jv.of_string slipshow)
   in
   let starting_state = get_starting_state () in
-  let slipshow = Slipshow.convert ~starting_state source in
+  let width, height = (1440, 1080) in
+  let slipshow = Slipshow.convert ~width ~height ~starting_state source in
   set_srcdoc slipshow
 
 let preview_compiled { stage; index; panels } delayed =

--- a/test/compiler/dimension.t/run.t
+++ b/test/compiler/dimension.t/run.t
@@ -2,17 +2,21 @@ Let's start with an empty file
 
   $ touch file.md
 
-  $ slipshow compile --help | grep "dim" -A 2
+  $ slipshow compile --help | grep "dim" -A 3
          -d WIDTHxHEIGHT, --dimension=WIDTHxHEIGHT, --dim=WIDTHxHEIGHT
-             The fixed dimension for your presentation. Can be either
-             WIDTHxHEIGHT where both are integers, or 4:3 (which corresponds to
-             1440x1080), or 16:9 (which corresponds to 1920x1080)
+         (absent=4:3)
+             The fixed dimension (in pixels) for your presentation. Can be
+             either WIDTHxHEIGHT where both are integers, or 4:3 (which
+             corresponds to 1440x1080), or 16:9 (which corresponds to
+             1920x1080).
 
-  $ slipshow serve --help | grep "dim" -A 2
+  $ slipshow serve --help | grep "dim" -A 3
          -d WIDTHxHEIGHT, --dimension=WIDTHxHEIGHT, --dim=WIDTHxHEIGHT
-             The fixed dimension for your presentation. Can be either
-             WIDTHxHEIGHT where both are integers, or 4:3 (which corresponds to
-             1440x1080), or 16:9 (which corresponds to 1920x1080)
+         (absent=4:3)
+             The fixed dimension (in pixels) for your presentation. Can be
+             either WIDTHxHEIGHT where both are integers, or 4:3 (which
+             corresponds to 1440x1080), or 16:9 (which corresponds to
+             1920x1080).
 
 We can provide the dimension with --dimension
 

--- a/test/compiler/dimension.t/run.t
+++ b/test/compiler/dimension.t/run.t
@@ -1,0 +1,42 @@
+Let's start with an empty file
+
+  $ touch file.md
+
+  $ slipshow compile --help | grep "dim" -A 2
+         -d WIDTHxHEIGHT, --dimension=WIDTHxHEIGHT, --dim=WIDTHxHEIGHT
+             The fixed dimension for your presentation. Can be either
+             WIDTHxHEIGHT where both are integers, or 4:3 (which corresponds to
+             1440x1080), or 16:9 (which corresponds to 1920x1080)
+
+  $ slipshow serve --help | grep "dim" -A 2
+         -d WIDTHxHEIGHT, --dimension=WIDTHxHEIGHT, --dim=WIDTHxHEIGHT
+             The fixed dimension for your presentation. Can be either
+             WIDTHxHEIGHT where both are integers, or 4:3 (which corresponds to
+             1440x1080), or 16:9 (which corresponds to 1920x1080)
+
+We can provide the dimension with --dimension
+
+  $ slipshow compile --dimension qfdesfesf file.md
+  slipshow: option '--dimension': Expected "4:3", "16:9", or two integers
+            separated by a 'x'
+  Usage: slipshow compile [OPTION]… [FILE.md]
+  Try 'slipshow compile --help' or 'slipshow --help' for more information.
+  [124]
+  $ slipshow compile --dimension wrongxefzefezf file.md
+  slipshow: option '--dimension': invalid value 'wrong', expected an integer
+  Usage: slipshow compile [OPTION]… [FILE.md]
+  Try 'slipshow compile --help' or 'slipshow --help' for more information.
+  [124]
+  $ slipshow compile --dimension 1920xwrong file.md
+  slipshow: option '--dimension': invalid value 'wrong', expected an integer
+  Usage: slipshow compile [OPTION]… [FILE.md]
+  Try 'slipshow compile --help' or 'slipshow --help' for more information.
+  [124]
+  $ slipshow compile --dimension 16:9 file.md
+  $ slipshow compile --dimension 4:3 file.md
+  $ slipshow compile --dimension 1920x1080 file.md
+
+-d and --dim work too
+
+  $ slipshow compile --dim 16:9 file.md
+  $ slipshow compile -d 16:9 file.md

--- a/test/engine/campus_du_libre.t/run.t
+++ b/test/engine/campus_du_libre.t/run.t
@@ -1,5 +1,5 @@
 
 
   $ slipshow compile cdl.md
-  $ cp cdl.html /tmp/
+$ cp cdl.html /tmp/
 


### PR DESCRIPTION
Adds a `--dimension` argument to specify the dimension in pixels of the presentation. Has an effect on the size of the open window, and the size of the slides and slips.

`"WIDTHxHEIGHT"` is accepted, as well as `"16:9"` (which is equivalent to 1920x1080) and `"4:3"` (which is equivalent to 1440x1080).

Still defaults to `4:3`.

Fix #122