### PR TITLE
Arguments in action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased
+
+### Compiler
+
+- Fix `children:` not working sometimes (#135)
+
+### Language
+
+- Add arguments to actions (#135)
+
+### Internal
+
+- Add compatibility with latest version of Cmdliner (#135)
+- Fix `"` sometimes being present in Cmarkit, removing the need for ~~hacks~~
+  workarounds. (#135)
+
+
 ## [v0.3.0] The return of the subslips (Friday 3rd July, 2025)
 
 ### Compiler

--- a/docs/syntax.rst
+++ b/docs/syntax.rst
@@ -230,6 +230,63 @@ It's sometimes useful to give the same attribute or class to all children of a g
    Slide 3
    ----
 
+Giving parameters to actions
+============================
+
+It is possible to give parameters to actions. Remember that we mentioned the
+``up`` attribute to move the screen, so that the attached element is at the top
+of it?
+
+.. code-block:: markdown
+
+   {up}
+   Some content
+
+When we press the "next" button, the screen "scrolls" so that "Some content" is
+at the top. However it is also possible to set the element we want to put at the top:
+
+
+.. code-block:: markdown
+
+   {#an-id}
+   Hello
+
+   {up="an-id"}
+   Some content
+
+In addition to this parameter we give to an action, we can also give named
+parameters:
+
+.. code-block:: markdown
+
+   {#an-id}
+   Hello
+
+   {up="~duration:3 an-id"}
+   Some content
+
+Here it will take 3 seconds to move the screen (which is likely to be too low!
+This is just an example).
+
+The syntax for the arguments is the following:
+
+* ``ARGS`` is a list of ``ARG``
+
+* ``ARG`` is either a ``NAMED_ARG`` or a ``POSITIONAL_ARG``
+
+* ``NAMED_ARG`` is of the form ``~ARGUMENT_NAME:ARGUMENT_VALUE`` where
+  ``ARGUMENT_NAME`` depends on the actions (defined below), and
+  ``ARGUMENT_VALUE`` is either a string without whitespace, or is quoted with
+  double quotes: ``"``.
+
+* ``POSITIONAL_ARG`` is of the form ``ARGUMENT_VALUE`` where ``ARGUMENT_VALUE``
+  is either a string without whitespace, or is quoted with double quotes: ``"``.
+
+Here is a made-up example, just to illustrate the syntax:
+
+.. code-block::
+
+   ~duration:1 id1 ~selector:".wrapper .figures" id2 "third positional argument"
 
 List of classes
 ===============
@@ -316,14 +373,22 @@ These attributes are actions that will be executed when a ``pause`` or ``step`` 
 ``down``
   Moves the screen untils the element is at the bottom of the screen.
 
+  Accepts ``~duration:FLOAT`` and ``margin:INT``.
+
 ``up``
   Moves the screen untils the element is at the top of the screen.
+
+  Accepts ``~duration:FLOAT`` and ``margin:INT``.
 
 ``center``
   Moves the screen untils the element is centered.
 
+  Accepts ``~duration:FLOAT`` and ``margin:INT``.
+
 ``focus``
   Focus on the element by zooming on it. Possible to specify multiple ids.
+
+  Accepts ``~duration:FLOAT`` and ``margin:INT``.
 
 ``unfocus``
   Unfocus by going back to the last position before a focus.

--- a/src/cli/main.ml
+++ b/src/cli/main.ml
@@ -14,7 +14,7 @@ let setup_log =
 
 let handle_error = function Ok _ as x -> x | Error (`Msg msg) -> Error msg
 
-module Conv = struct
+module Custom_conv = struct
   let io std =
     let parser_ s =
       match s with "-" -> Ok std | s -> Ok (`File (Fpath.v s))
@@ -86,7 +86,7 @@ module Compile_args = struct
     in
     Arg.(
       value
-      & opt Conv.dimension (1440, 1080)
+      & opt Custom_conv.dimension (1440, 1080)
       & info ~docv:"WIDTHxHEIGHT" ~doc [ "d"; "dimension"; "dim" ])
 
   let output =
@@ -96,7 +96,7 @@ module Compile_args = struct
     in
     Arg.(
       value
-      & opt (some Conv.output) None
+      & opt (some Custom_conv.output) None
       & info ~docv:"PATH" ~doc [ "o"; "output" ])
 
   let input =
@@ -104,7 +104,7 @@ module Compile_args = struct
       "$(docv) is the CommonMark file to process. Reads from $(b,stdin) if \
        $(b,-) is specified."
     in
-    Arg.(value & pos 0 Conv.input `Stdin & info [] ~doc ~docv:"FILE.md")
+    Arg.(value & pos 0 Custom_conv.input `Stdin & info [] ~doc ~docv:"FILE.md")
 
   type compile_args = {
     math_link : string option;

--- a/src/compiler/compile.ml
+++ b/src/compiler/compile.ml
@@ -87,7 +87,7 @@ module Stage1 = struct
 
   let handle_includes read_file current_path m (attrs, meta) =
     match (Attributes.find "include" attrs, Attributes.find "src" attrs) with
-    | Some (_, None), Some (_, Some ({v = src; _}, _)) -> (
+    | Some (_, None), Some (_, Some ({ v = src; _ }, _)) -> (
         let relativized_path =
           Path_entering.relativize current_path (Fpath.v src)
         in
@@ -223,6 +223,35 @@ module Stage1 = struct
       | `Kv (("unfocus", m), v) -> Some (`Kv (("unfocus-at-unpause", m), v))
       | `Kv (("unreveal", m), v) -> Some (`Kv (("unreveal-at-unpause", m), v))
       | `Kv (("unstatic", m), v) -> Some (`Kv (("unstatic-at-unpause", m), v))
+      (* TODO: Improve this (eg by moving it to another phase) *)
+      | `Kv (("children:up", m), v) ->
+          Some (`Kv (("children:up-at-unpause", m), v))
+      | `Kv (("children:center", m), v) ->
+          Some (`Kv (("children:center-at-unpause", m), v))
+      | `Kv (("children:down", m), v) ->
+          Some (`Kv (("children:down-at-unpause", m), v))
+      | `Kv (("children:exec", m), v) ->
+          Some (`Kv (("children:exec-at-unpause", m), v))
+      | `Kv (("children:scroll", m), v) ->
+          Some (`Kv (("children:scroll-at-unpause", m), v))
+      | `Kv (("children:enter", m), v) ->
+          Some (`Kv (("children:enter-at-unpause", m), v))
+      | `Kv (("children:emph", m), v) ->
+          Some (`Kv (("children:emph-at-unpause", m), v))
+      | `Kv (("children:focus", m), v) ->
+          Some (`Kv (("children:focus-at-unpause", m), v))
+      | `Kv (("children:reveal", m), v) ->
+          Some (`Kv (("children:reveal-at-unpause", m), v))
+      | `Kv (("children:static", m), v) ->
+          Some (`Kv (("children:static-at-unpause", m), v))
+      | `Kv (("children:unemph", m), v) ->
+          Some (`Kv (("children:unemph-at-unpause", m), v))
+      | `Kv (("children:unfocus", m), v) ->
+          Some (`Kv (("children:unfocus-at-unpause", m), v))
+      | `Kv (("children:unreveal", m), v) ->
+          Some (`Kv (("children:unreveal-at-unpause", m), v))
+      | `Kv (("children:unstatic", m), v) ->
+          Some (`Kv (("children:unstatic-at-unpause", m), v))
       | x -> Some x
     in
     Ast.Mapper.make ~block ~inline ~attrs ()
@@ -388,7 +417,10 @@ module Stage3 = struct
           | Some b -> b
         in
         let attrs =
-          if Attributes.mem "no-enter" attrs then attrs
+          if
+            Attributes.mem "no-enter" attrs
+            || Attributes.mem "enter-at-unpause" attrs
+          then attrs
           else Attributes.add ("enter-at-unpause", Meta.none) None attrs
         in
         let attrs = Mapper.map_attrs m attrs in

--- a/src/compiler/compile.ml
+++ b/src/compiler/compile.ml
@@ -85,23 +85,9 @@ module Stage1 = struct
               (Ast.SlipScript ((cb, (Mapper.map_attrs m attrs, meta)), meta2))
         | _ -> Mapper.default)
 
-  let remove_quotes src =
-    (* This is a horrible hack due to the fact that our current attribute
-       parsing leaves the quotes...
-
-       It was not spotted until now since leftover quotes are
-       interpreted as quotes by HTML, but as we use more attributes in
-       cmarkit, it's going to be really annoying.
-
-       Needs to be fixed in cmarkit... *)
-    if src.[0] = '"' && src.[String.length src - 1] = '"' then
-      String.sub src 1 (String.length src - 2)
-    else src
-
   let handle_includes read_file current_path m (attrs, meta) =
     match (Attributes.find "include" attrs, Attributes.find "src" attrs) with
-    | Some (_, None), Some (_, Some (src, _)) -> (
-        let src = remove_quotes src in
+    | Some (_, None), Some (_, Some ({v = src; _}, _)) -> (
         let relativized_path =
           Path_entering.relativize current_path (Fpath.v src)
         in

--- a/src/engine/controller.ml
+++ b/src/engine/controller.ml
@@ -19,28 +19,28 @@ let keyboard_setup (window : Universe.Window.t) =
           let _ : unit Fut.t =
             Universe.Move.move_relative_pure
               ~x:(30. *. 1. /. current_coord.scale)
-              window ~delay:0.
+              window ~duration:0.
           in
           ()
       | "j" ->
           let _ : unit Fut.t =
             Universe.Move.move_relative_pure
               ~x:(-30. *. 1. /. current_coord.scale)
-              window ~delay:0.
+              window ~duration:0.
           in
           ()
       | "k" ->
           let _ : unit Fut.t =
             Universe.Move.move_relative_pure
               ~y:(30. *. 1. /. current_coord.scale)
-              window ~delay:0.
+              window ~duration:0.
           in
           ()
       | "i" ->
           let _ : unit Fut.t =
             Universe.Move.move_relative_pure
               ~y:(-30. *. 1. /. current_coord.scale)
-              window ~delay:0.
+              window ~duration:0.
           in
           ()
       | "ArrowRight" | "ArrowDown" | "PageDown" | " " ->
@@ -51,13 +51,13 @@ let keyboard_setup (window : Universe.Window.t) =
           ()
       | "z" ->
           let _ : unit Fut.t =
-            Universe.Move.move_relative_pure ~scale:1.02 window ~delay:0.
+            Universe.Move.move_relative_pure ~scale:1.02 window ~duration:0.
           in
           ()
       | "Z" ->
           let _ : unit Fut.t =
             Universe.Move.move_relative_pure ~scale:(1. /. 1.02) window
-              ~delay:0.
+              ~duration:0.
           in
           ()
       | _ -> ()

--- a/src/engine/main.ml
+++ b/src/engine/main.ml
@@ -27,7 +27,9 @@ let start ~width ~height ~id ~step =
   let* () =
     match Brr.El.find_first_by_selector (Jstr.v "[slipshow-entry-point]") with
     | None -> Fut.return ()
-    | Some elem -> Step.Actions.enter window elem |> Undoable.discard
+    | Some elem ->
+        Step.Actions.Enter.do_ window { elem; duration = None; margin = None }
+        |> Undoable.discard
   in
   let* () =
     match initial_step with

--- a/src/engine/main.ml
+++ b/src/engine/main.ml
@@ -22,7 +22,7 @@ let start ~width ~height ~id ~step =
   in
   let _history = Browser.History.set_hash "" in
   let* () =
-    Step.Action_scheduler.setup_pause_ancestors () |> Undoable.discard
+    Step.Action_scheduler.setup_pause_ancestors window () |> Undoable.discard
   in
   let* () =
     match Brr.El.find_first_by_selector (Jstr.v "[slipshow-entry-point]") with

--- a/src/engine/step/action_scheduler.ml
+++ b/src/engine/step/action_scheduler.ml
@@ -80,11 +80,6 @@ module AttributeActions = struct
       else Undoable.return ()
     in
     let v = Jstr.to_string v in
-    let v =
-      if String.length v > 1 && v.[0] = '"' && v.[String.length v - 1] = '"'
-      then String.sub v 1 (String.length v - 2)
-      else v
-    in
     let$$ args = Actions.Focus.parse_args elem v in
     action args
 

--- a/src/engine/step/action_scheduler.ml
+++ b/src/engine/step/action_scheduler.ml
@@ -1,22 +1,4 @@
-let all_actions =
-  [
-    "center-at-unpause";
-    "down-at-unpause";
-    "emph-at-unpause";
-    "enter-at-unpause";
-    "exec-at-unpause";
-    "focus-at-unpause";
-    "pause";
-    "reveal-at-unpause";
-    "scroll-at-unpause";
-    "static-at-unpause";
-    "step";
-    "unemph-at-unpause";
-    "unfocus-at-unpause";
-    "unreveal-at-unpause";
-    "unstatic-at-unpause";
-    "up-at-unpause";
-  ]
+let all_actions = List.map (fun (module M : Actions.S) -> M.on) Actions.all
 
 let is_action elem =
   List.exists
@@ -32,172 +14,45 @@ let find_next_pause_or_step () =
   Brr.El.find_first_by_selector (Jstr.v all_action_selector)
 
 open Undoable.Syntax
-open Fut.Syntax
 
 module AttributeActions = struct
-  let as_id elem v =
-    if Jstr.equal Jstr.empty v then Some elem
-    else
-      let id = Jstr.concat [ Jstr.v "#"; v ] in
-      match Brr.El.find_first_by_selector id with
-      | None -> None
-      | Some elem -> Some elem
+  let ( let$ ) x f = match x with None -> Undoable.return () | Some x -> f x
 
-  let as_ids elem v =
-    if Jstr.equal Jstr.empty v then Some [ elem ]
-    else
-      Some
-        (Jstr.cuts ~sep:(Jstr.v " ") v
-        |> List.filter_map (fun id ->
-               Brr.El.find_first_by_selector (Jstr.concat [ Jstr.v "#"; id ])))
+  let ( let$$ ) x f =
+    match x with
+    | Error (`Msg s) ->
+        Brr.Console.(log [ "Error:"; s ]);
+        Undoable.return ()
+    | Ok x -> f x
 
-  let act ?(remove_class = true) ~on:at_ ~payload action elem =
-    let ( let$ ) x f =
-      match x with None -> Undoable.return () | Some x -> f x
-    in
-    let$ v = Brr.El.at (Jstr.v at_) elem in
+  let activate ?(remove_class = true) (module Action : Actions.S) window elem =
+    let on = Action.on in
+    let$ v = Brr.El.at (Jstr.v on) elem in
     let> () =
-      if remove_class then Undoable.Browser.set_at at_ None elem
-      else Undoable.return ()
-    in
-    let$ payload = payload elem v in
-    action payload
-
-  let act3 ?(remove_class = true) ~on:at_ (module Move : Actions.S) window elem
-      =
-    let ( let$ ) x f =
-      match x with None -> Undoable.return () | Some x -> f x
-    in
-    let ( let$$ ) x f =
-      match x with
-      | Error (`Msg s) ->
-          Brr.Console.(log [ "Error:"; s ]);
-          Undoable.return ()
-      | Ok x -> f x
-    in
-    let$ v = Brr.El.at (Jstr.v at_) elem in
-    let> () =
-      if remove_class then Undoable.Browser.set_at at_ None elem
+      if remove_class then Undoable.Browser.set_at on None elem
       else Undoable.return ()
     in
     let v = Jstr.to_string v in
-    let$$ args = Move.parse_args elem v in
-    Move.do_ window args
-
-  let act2 ?(remove_class = true) ~on:at_ action elem =
-    let ( let$ ) x f =
-      match x with None -> Undoable.return () | Some x -> f x
-    in
-    let ( let$$ ) x f =
-      match x with
-      | Error (`Msg s) ->
-          Brr.Console.(log [ "Error:"; s ]);
-          Undoable.return ()
-      | Ok x -> f x
-    in
-    let$ v = Brr.El.at (Jstr.v at_) elem in
-    let> () =
-      if remove_class then Undoable.Browser.set_at at_ None elem
-      else Undoable.return ()
-    in
-    let v = Jstr.to_string v in
-    let$$ args = Actions.Focus.parse_args elem v in
-    action args
-
-  let up window = act3 ~on:"up-at-unpause" (module Actions.Up) window
-  let down window = act3 ~on:"down-at-unpause" (module Actions.Down) window
-
-  let center window =
-    act3 ~on:"center-at-unpause" (module Actions.Center) window
-
-  let scroll window =
-    act3 ~on:"uscroll-at-unpause" (module Actions.Scroll) window
-
-  let enter = act3 ~on:"enter-at-unpause" (module Actions.Enter)
-  let unstatic = act3 ~on:"unstatic-at-unpause" (module Actions.Unstatic)
-  let static = act3 ~on:"static-at-unpause" (module Actions.Static)
-  let focus window = act2 ~on:"focus-at-unpause" (Actions.Focus.do_ window)
-
-  let unfocus window =
-    act ~on:"unfocus-at-unpause"
-      ~payload:(fun _ _ -> Some ())
-      (Actions.unfocus window)
-
-  let reveal = act3 ~on:"reveal-at-unpause" (module Actions.Reveal)
-  let unreveal = act3 ~on:"unreveal-at-unpause" (module Actions.Unreveal)
-  let emph = act3 ~on:"emph-at-unpause" (module Actions.Emph)
-  let unemph = act3 ~on:"unemph-at-unpause" (module Actions.Unemph)
-
-  let pause window elem =
-    act ~on:"pause" ~payload:as_ids
-      (fun target -> Actions.Pause.do_ window target)
-      elem
-
-  let step _window elem =
-    act ~on:"step" ~payload:as_id (fun _ -> Undoable.return ()) elem
-
-  let execute window elem =
-    let action elem =
-      let body = Jv.get (Brr.El.to_jv elem) "innerHTML" |> Jv.to_jstr in
-      Brr.Console.(log [ body ]);
-      let args = Jv.Function.[ ("slip", Fun.id) ] in
-      let f = Jv.Function.v ~body ~args in
-      let undos_ref = ref [] in
-      let arg = Javascript_api.slip window undos_ref in
-      let u = f arg in
-      let undo () =
-        try Fut.return (ignore @@ Jv.call u "undo" [||])
-        with _ ->
-          List.fold_left
-            (fun acc f ->
-              let* () = acc in
-              f ())
-            (Fut.return ()) !undos_ref
-      in
-      Undoable.return ~undo ()
-    in
-    try
-      act ~on:"exec-at-unpause" ~payload:as_ids (Undoable.List.iter action) elem
-    with e ->
-      Brr.Console.(
-        log
-          [ "An exception occurred when trying to execute a custom script:"; e ]);
-      Undoable.return ()
+    let$$ args = Action.parse_args elem v in
+    Action.do_ window args
 
   let do_ window elem =
-    let do_ =
-     fun acc f ->
-      let> _acc = acc in
-      f window elem
-    in
-    List.fold_left do_ (Undoable.return ())
-      [
-        pause;
-        step;
-        unstatic;
-        static;
-        unreveal;
-        reveal;
-        unfocus;
-        center;
-        enter;
-        down;
-        focus;
-        up;
-        scroll;
-        emph;
-        unemph;
-        execute;
-      ]
+    let do_ = fun m -> activate m window elem in
+    Undoable.List.iter do_ Actions.all
 end
 
-let setup_pause_ancestors () =
+let setup_pause_ancestors window () =
   Brr.El.fold_find_by_selector
     (fun elem acc ->
       let> () = acc in
       let open AttributeActions in
-      act ~remove_class:false ~on:"pause" ~payload:as_id Actions.Pause.setup
-        elem)
+      activate ~remove_class:false
+        (module struct
+          include Actions.Pause
+
+          let do_ _window = setup
+        end)
+        window elem)
     (Jstr.v "[pause]") (Undoable.return ())
 
 let update_history () =

--- a/src/engine/step/action_scheduler.ml
+++ b/src/engine/step/action_scheduler.ml
@@ -112,7 +112,7 @@ module AttributeActions = struct
   let unemph = act ~on:"unemph-at-unpause" ~payload:as_ids Actions.unemph
 
   let pause elem =
-    act ~on:"pause" ~payload:as_id (fun target -> Actions.pause target) elem
+    act ~on:"pause" ~payload:as_id (fun target -> Actions.Pause.do_ target) elem
 
   let step elem =
     act ~on:"step" ~payload:as_id (fun _ -> Undoable.return ()) elem
@@ -177,7 +177,7 @@ let setup_pause_ancestors () =
     (fun elem acc ->
       let> () = acc in
       let open AttributeActions in
-      act ~remove_class:false ~on:"pause" ~payload:as_id Actions.setup_pause
+      act ~remove_class:false ~on:"pause" ~payload:as_id Actions.Pause.setup
         elem)
     (Jstr.v "[pause]") (Undoable.return ())
 

--- a/src/engine/step/action_scheduler.ml
+++ b/src/engine/step/action_scheduler.ml
@@ -67,6 +67,13 @@ module AttributeActions = struct
     let ( let$ ) x f =
       match x with None -> Undoable.return () | Some x -> f x
     in
+    let ( let$$ ) x f =
+      match x with
+      | Error (`Msg s) ->
+          Brr.Console.(log [ "Error:"; s ]);
+          Undoable.return ()
+      | Ok x -> f x
+    in
     let$ v = Brr.El.at (Jstr.v at_) elem in
     let> () =
       if remove_class then Undoable.Browser.set_at at_ None elem
@@ -78,8 +85,8 @@ module AttributeActions = struct
       then String.sub v 1 (String.length v - 2)
       else v
     in
-    let margin, delay, elems = Actions.parse_focus elem v in
-    action ~margin ~delay elems
+    let$$ args = Actions.Focus.parse_args elem v in
+    action args
 
   let up window = act ~on:"up-at-unpause" ~payload:as_id (Actions.up window)
 
@@ -97,7 +104,7 @@ module AttributeActions = struct
 
   let unstatic = act ~on:"unstatic-at-unpause" ~payload:as_ids Actions.unstatic
   let static = act ~on:"static-at-unpause" ~payload:as_ids Actions.static
-  let focus window = act2 ~on:"focus-at-unpause" (Actions.focus window)
+  let focus window = act2 ~on:"focus-at-unpause" (Actions.Focus.do_ window)
 
   let unfocus window =
     act ~on:"unfocus-at-unpause"

--- a/src/engine/step/action_scheduler.ml
+++ b/src/engine/step/action_scheduler.ml
@@ -81,7 +81,7 @@ module AttributeActions = struct
     in
     let v = Jstr.to_string v in
     let v =
-      if v.[0] = '"' && v.[String.length v - 1] = '"' && String.length v > 1
+      if String.length v > 1 && v.[0] = '"' && v.[String.length v - 1] = '"'
       then String.sub v 1 (String.length v - 2)
       else v
     in

--- a/src/engine/step/action_scheduler.ml
+++ b/src/engine/step/action_scheduler.ml
@@ -28,6 +28,7 @@ module AttributeActions = struct
   let activate ?(remove_class = true) (module Action : Actions.S) window elem =
     let on = Action.on in
     let$ v = Brr.El.at (Jstr.v on) elem in
+    Brr.Console.(log [ "Activating"; Action.action_name; "by"; elem ]);
     let> () =
       if remove_class then Undoable.Browser.set_at on None elem
       else Undoable.return ()

--- a/src/engine/step/action_scheduler.ml
+++ b/src/engine/step/action_scheduler.ml
@@ -63,8 +63,8 @@ module AttributeActions = struct
     let$ payload = payload elem v in
     action payload
 
-  let act3 ?(remove_class = true) ~on:at_ (module Move : Actions.Move) window
-      elem =
+  let act3 ?(remove_class = true) ~on:at_ (module Move : Actions.S) window elem
+      =
     let ( let$ ) x f =
       match x with None -> Undoable.return () | Some x -> f x
     in
@@ -113,11 +113,9 @@ module AttributeActions = struct
   let scroll window =
     act3 ~on:"uscroll-at-unpause" (module Actions.Scroll) window
 
-  let enter window =
-    act ~on:"enter-at-unpause" ~payload:as_id (Actions.enter window)
-
-  let unstatic = act ~on:"unstatic-at-unpause" ~payload:as_ids Actions.unstatic
-  let static = act ~on:"static-at-unpause" ~payload:as_ids Actions.static
+  let enter = act3 ~on:"enter-at-unpause" (module Actions.Enter)
+  let unstatic = act3 ~on:"unstatic-at-unpause" (module Actions.Unstatic)
+  let static = act3 ~on:"static-at-unpause" (module Actions.Static)
   let focus window = act2 ~on:"focus-at-unpause" (Actions.Focus.do_ window)
 
   let unfocus window =
@@ -125,15 +123,17 @@ module AttributeActions = struct
       ~payload:(fun _ _ -> Some ())
       (Actions.unfocus window)
 
-  let reveal = act ~on:"reveal-at-unpause" ~payload:as_ids Actions.reveal
-  let unreveal = act ~on:"unreveal-at-unpause" ~payload:as_ids Actions.unreveal
-  let emph = act ~on:"emph-at-unpause" ~payload:as_ids Actions.emph
-  let unemph = act ~on:"unemph-at-unpause" ~payload:as_ids Actions.unemph
+  let reveal = act3 ~on:"reveal-at-unpause" (module Actions.Reveal)
+  let unreveal = act3 ~on:"unreveal-at-unpause" (module Actions.Unreveal)
+  let emph = act3 ~on:"emph-at-unpause" (module Actions.Emph)
+  let unemph = act3 ~on:"unemph-at-unpause" (module Actions.Unemph)
 
-  let pause elem =
-    act ~on:"pause" ~payload:as_id (fun target -> Actions.Pause.do_ target) elem
+  let pause window elem =
+    act ~on:"pause" ~payload:as_ids
+      (fun target -> Actions.Pause.do_ window target)
+      elem
 
-  let step elem =
+  let step _window elem =
     act ~on:"step" ~payload:as_id (fun _ -> Undoable.return ()) elem
 
   let execute window elem =
@@ -168,7 +168,7 @@ module AttributeActions = struct
     let do_ =
      fun acc f ->
       let> _acc = acc in
-      f elem
+      f window elem
     in
     List.fold_left do_ (Undoable.return ())
       [
@@ -178,16 +178,16 @@ module AttributeActions = struct
         static;
         unreveal;
         reveal;
-        unfocus window;
-        center window;
-        enter window;
-        down window;
-        focus window;
-        up window;
-        scroll window;
+        unfocus;
+        center;
+        enter;
+        down;
+        focus;
+        up;
+        scroll;
         emph;
         unemph;
-        execute window;
+        execute;
       ]
 end
 

--- a/src/engine/step/action_scheduler.mli
+++ b/src/engine/step/action_scheduler.mli
@@ -1,4 +1,4 @@
 val is_action : Brr.El.t -> bool
 val all_action_selector : string
-val setup_pause_ancestors : unit -> unit Undoable.t
+val setup_pause_ancestors : Universe.Window.t -> unit -> unit Undoable.t
 val next : Universe.Window.t -> unit -> unit Undoable.t option

--- a/src/engine/step/actions.ml
+++ b/src/engine/step/actions.ml
@@ -9,18 +9,51 @@ let parse_string s =
     || ('0' <= c && c <= '9')
     || c = '_'
   in
-  let rec consume_ws idx = if is_ws idx then consume_ws (idx + 1) else idx in
+  let rec consume_ws idx =
+    if idx >= String.length s then idx
+    else if is_ws idx then consume_ws (idx + 1)
+    else idx
+  in
   let rec consume_non_ws idx =
-    if not (is_ws idx) then consume_non_ws (idx + 1) else idx
+    if idx >= String.length s then idx
+    else if not (is_ws idx) then consume_non_ws (idx + 1)
+    else idx
   in
   let rec consume_alpha idx =
-    if is_alpha idx then consume_alpha (idx + 1) else idx
+    if idx >= String.length s then idx
+    else if is_alpha idx then consume_alpha (idx + 1)
+    else idx
   in
-  let rec parse_nameds acc idx =
+  let quoted_string idx =
+    let rec take_inside_quoted_string acc idx =
+      match s.[idx] with
+      | '"' -> (acc |> List.rev |> List.to_seq |> String.of_seq, idx + 1)
+      | '\\' -> take_inside_quoted_string (s.[idx + 1] :: acc) (idx + 2)
+      | _ -> take_inside_quoted_string (s.[idx] :: acc) (idx + 1)
+    in
+    take_inside_quoted_string [] (idx + 1)
+  in
+  let parse_arg idx =
+    match s.[idx] with
+    | '"' -> quoted_string idx
+    | _ ->
+        let idx0 = idx in
+        let idx = consume_non_ws idx in
+        let arg = String.sub s idx0 (idx - idx0) in
+        (arg, idx)
+  in
+  let repeat parser idx =
+    let rec do_ acc idx =
+      match parser idx with
+      | None -> (List.rev acc, idx)
+      | Some (x, idx) -> do_ (x :: acc) idx
+    in
+    do_ [] idx
+  in
+  let parse_nameds =
     let parse_name idx =
       let idx0 = idx in
       let idx = consume_alpha idx in
-      Format.printf "After consuming alpha idx is %d" idx;
       let name = String.sub s idx0 (idx - idx0) in
       (name, idx)
     in
@@ -28,12 +61,6 @@ let parse_string s =
       match s.[idx] with
       | ':' -> idx + 1
       | _ -> failwith "no : after named argument"
-    in
-    let parse_arg idx =
-      let idx0 = idx in
-      let idx = consume_non_ws idx in
-      let arg = String.sub s idx0 (idx - idx0) in
-      (arg, idx)
     in
     let parse_named idx =
       let idx = consume_ws idx in
@@ -46,15 +73,69 @@ let parse_string s =
           Some ((name, arg), idx)
       | _ -> None
     in
-    match parse_named idx with
-    | None -> (List.rev acc, idx)
-    | Some (x, idx) -> parse_nameds (x :: acc) idx
+    repeat parse_named
   in
-  let parse_others idx = String.sub s idx (String.length s - idx) in
-  let nameds, idx = parse_nameds [] 0 in
+  let parse_other idx =
+    if idx >= String.length s then None
+    else
+      let idx = consume_ws idx in
+      let res =
+        match s.[idx] with '"' -> quoted_string idx | _ -> parse_arg idx
+      in
+      Some res
+  in
+  let parse_others = repeat parse_other in
+  let nameds, idx = parse_nameds 0 in
   let idx = consume_ws idx in
-  let others = parse_others idx in
+  let others, _idx = parse_others idx in
   (nameds, others)
+
+let parse_string s =
+  try Ok (parse_string s)
+  with _ (* TODO: finer grain catch and better error messages *) ->
+    Error (`Msg "Failed when trying to parse argument")
+
+(* Let's remove angstrom parsing, but keep it around if the manual parsing
+   becomes too cumbersome.
+
+   Angstrom adds 10th of Ko (out of eg 300Ko for simple presentations).
+
+   So it's close to being negligible but not completely *)
+
+(* let parse_string s = *)
+(*   let open Angstrom in *)
+(*   let quoted_string = *)
+(*     let quoted_string_char = *)
+(*       char '\\' *> choice [ char '"' *> return '"'; char '\\' *> return '\\' ] *)
+(*     in *)
+(*     char '"' *)
+(*     *> many (quoted_string_char <|> satisfy (fun c -> c <> '"' && c <> '\\')) *)
+(*     <* char '"' *)
+(*     >>| fun chars -> String.of_seq (List.to_seq chars) *)
+(*   in *)
+(*   let is_ws = function *)
+(*     | '\x20' | '\x0a' | '\x0d' | '\x09' -> true *)
+(*     | _ -> false *)
+(*   in *)
+(*   let ws = skip_while is_ws in *)
+(*   let named = *)
+(*     let is_alpha c = *)
+(*       ('a' <= c && c <= 'z') *)
+(*       || ('A' <= c && c <= 'Z') *)
+(*       || ('0' <= c && c <= '9') *)
+(*       || c = '_' *)
+(*     in *)
+(*     let name = take_while is_alpha in *)
+(*     let argument = quoted_string <|> take_till is_ws in *)
+(*     ws *> char '~' *> name >>= fun name -> *)
+(*     char ':' *> ws *> argument >>| fun arg -> (name, arg) *)
+(*   in *)
+(*   let rest = quoted_string <|> take_while (fun _ -> true) <* end_of_input in *)
+(*   let parser = *)
+(*     many named >>= fun named -> *)
+(*     ws *> rest >>| fun main -> (named, main) *)
+(*   in *)
+(*   parse_string ~consume:All parser s |> Result.get_ok *)
 
 let do_to_root elem f =
   let is_root elem =
@@ -72,49 +153,48 @@ let do_to_root elem f =
   do_rec elem
 
 let setup_pause elem =
-  let> () = Undoable.Browser.set_class "pauseTarget" true elem in
+  let open Undoable in
+  let> () = Browser.set_class "pauseTarget" true elem in
   do_to_root elem @@ fun elem ->
   match Brr.El.at (Jstr.v "pauseAncestorMultiplicity") elem with
   | None ->
-      let> () = Undoable.Browser.set_class "pauseAncestor" true elem in
-      Undoable.Browser.set_at "pauseAncestorMultiplicity"
-        (Some (Jstr.of_int 1))
-        elem
+      let> () = Browser.set_class "pauseAncestor" true elem in
+      Browser.set_at "pauseAncestorMultiplicity" (Some (Jstr.of_int 1)) elem
   | Some i -> (
       match Jstr.to_int i with
       | None ->
           Brr.Console.(
             log [ "Error: wrong value to pauseAncestorMultiplicity:"; i ]);
-          Undoable.Browser.set_class "pauseAncestor" true elem
+          Browser.set_class "pauseAncestor" true elem
       | Some i ->
           let> () =
-            Undoable.Browser.set_at "pauseAncestorMultiplicity"
+            Browser.set_at "pauseAncestorMultiplicity"
               (Some (Jstr.of_int (i + 1)))
               elem
           in
-          Undoable.Browser.set_class "pauseAncestor" true elem)
+          Browser.set_class "pauseAncestor" true elem)
 
+(* TODO: factor pause and setup_pause duplicated logic *)
 let pause elem =
-  let> () = Undoable.Browser.set_class "pauseTarget" false elem in
+  let open Undoable in
+  let> () = Browser.set_class "pauseTarget" false elem in
   do_to_root elem @@ fun elem ->
   match Brr.El.at (Jstr.v "pauseAncestorMultiplicity") elem with
   | None ->
       Brr.Console.(
         log [ "Error: pauseAncestorMultiplicity was supposed to be some"; elem ]);
-      Undoable.Browser.set_class "pauseAncestor" false elem
+      Browser.set_class "pauseAncestor" false elem
   | Some i -> (
       match Jstr.to_int i with
       | None ->
           Brr.Console.(
             log [ "Error: wrong value to pauseAncestorMultiplicity:"; i ]);
-          Undoable.Browser.set_class "pauseAncestor" false elem
+          Browser.set_class "pauseAncestor" false elem
       | Some i when i <= 1 ->
-          let> () =
-            Undoable.Browser.set_at "pauseAncestorMultiplicity" None elem
-          in
-          Undoable.Browser.set_class "pauseAncestor" false elem
+          let> () = Browser.set_at "pauseAncestorMultiplicity" None elem in
+          Browser.set_class "pauseAncestor" false elem
       | Some i ->
-          Undoable.Browser.set_at "pauseAncestorMultiplicity"
+          Browser.set_at "pauseAncestorMultiplicity"
             (Some (Jstr.of_int (i - 1)))
             elem)
 
@@ -158,36 +238,45 @@ let unstatic elems =
 let static elem =
   Undoable.List.iter (Undoable.Browser.set_class "unstatic" false) elem
 
-let parse_elems elem v =
-  let v = Jstr.of_string v in
-  if Jstr.equal Jstr.empty v then [ elem ]
-  else
-    Jstr.cuts ~sep:(Jstr.v " ") v
-    |> List.filter_map (fun id ->
-           Brr.El.find_first_by_selector (Jstr.concat [ Jstr.v "#"; id ]))
+module Focus = struct
+  type args = {
+    margin : float option;
+    delay : float option;
+    elems : Brr.El.t list;
+  }
 
-let find_named_arg name named_args =
-  List.find_map
-    (function n, v when String.equal n name -> Some v | _ -> None)
-    named_args
+  let parse_elems elem v =
+    let v = List.map Jstr.of_string v in
+    match v with
+    | [] -> [ elem ]
+    | _ ->
+        v
+        |> List.filter_map (fun id ->
+               Brr.El.find_first_by_selector (Jstr.concat [ Jstr.v "#"; id ]))
 
-let parse_focus elem s =
-  let named_args, args = parse_string s in
-  let elems = parse_elems elem args in
-  let delay =
-    find_named_arg "delay" named_args
-    |> Option.map Float.of_string |> Option.value ~default:1.
-  in
-  let margin =
-    find_named_arg "margin" named_args
-    |> Option.map Float.of_string |> Option.value ~default:0.
-  in
-  (margin, delay, elems)
+  let find_named_arg name named_args =
+    List.find_map
+      (function n, v when String.equal n name -> Some v | _ -> None)
+      named_args
 
-let focus window ~margin ~delay elems =
-  let> () = State.Focus.push (Universe.State.get_coord ()) in
-  (* We focus 1px more in order to avoid off-by-one error due to round errors *)
-  Universe.Move.focus ~margin ~delay window elems
+  let parse_args elem s =
+    let ( let$ ) = Fun.flip Result.map in
+    let$ named_args, args = parse_string s in
+    let elems = parse_elems elem args in
+    let delay =
+      find_named_arg "delay" named_args |> Option.map Float.of_string
+    in
+    let margin =
+      find_named_arg "margin" named_args |> Option.map Float.of_string
+    in
+    { margin; delay; elems }
+
+  let do_ window { margin; delay; elems } =
+    let> () = State.Focus.push (Universe.State.get_coord ()) in
+    let margin = Option.value ~default:0. margin in
+    let delay = Option.value ~default:1. delay in
+    Universe.Move.focus ~margin ~delay window elems
+end
 
 let unfocus window () =
   let> coord = State.Focus.pop () in

--- a/src/engine/step/actions.ml
+++ b/src/engine/step/actions.ml
@@ -71,18 +71,16 @@ let parse_string s =
           let idx = parse_column idx in
           let arg, idx = parse_arg idx in
           Some ((name, arg), idx)
-      | _ -> None
+      | (exception Invalid_argument _) | _ -> None
     in
     repeat parse_named
   in
   let parse_other idx =
-    if idx >= String.length s then None
-    else
-      let idx = consume_ws idx in
-      let res =
-        match s.[idx] with '"' -> quoted_string idx | _ -> parse_arg idx
-      in
-      Some res
+    let idx = consume_ws idx in
+    match s.[idx] with
+    | '"' -> Some (quoted_string idx)
+    | _ -> Some (parse_arg idx)
+    | exception Invalid_argument _ -> None
   in
   let parse_others = repeat parse_other in
   let nameds, idx = parse_nameds 0 in

--- a/src/engine/step/actions.ml
+++ b/src/engine/step/actions.ml
@@ -1,470 +1,65 @@
-open Undoable.Syntax
+include Actions_
 
-module Parse = struct
-  let parse_string s =
-    let is_ws idx = match s.[idx] with '\n' | ' ' -> true | _ -> false in
-    let is_alpha idx =
-      let c = s.[idx] in
-      ('a' <= c && c <= 'z')
-      || ('A' <= c && c <= 'Z')
-      || ('0' <= c && c <= '9')
-      || c = '_'
-    in
-    let rec consume_ws idx =
-      if idx >= String.length s then idx
-      else if is_ws idx then consume_ws (idx + 1)
-      else idx
-    in
-    let rec consume_non_ws idx =
-      if idx >= String.length s then idx
-      else if not (is_ws idx) then consume_non_ws (idx + 1)
-      else idx
-    in
-    let rec consume_alpha idx =
-      if idx >= String.length s then idx
-      else if is_alpha idx then consume_alpha (idx + 1)
-      else idx
-    in
-    let quoted_string idx =
-      let rec take_inside_quoted_string acc idx =
-        match s.[idx] with
-        | '"' -> (acc |> List.rev |> List.to_seq |> String.of_seq, idx + 1)
-        | '\\' -> take_inside_quoted_string (s.[idx + 1] :: acc) (idx + 2)
-        | _ -> take_inside_quoted_string (s.[idx] :: acc) (idx + 1)
-      in
-      take_inside_quoted_string [] idx
-    in
-    let parse_unquoted_string idx =
-      let idx0 = idx in
-      let idx = consume_non_ws idx in
-      let arg = String.sub s idx0 (idx - idx0) in
-      (arg, idx)
-    in
-    let parse_arg idx =
-      match s.[idx] with
-      | '"' -> quoted_string (idx + 1)
-      | _ -> parse_unquoted_string idx
-    in
-    let repeat parser idx =
-      let rec do_ acc idx =
-        match parser idx with
-        | None -> (List.rev acc, idx)
-        | Some (x, idx) -> do_ (x :: acc) idx
-      in
-      do_ [] idx
-    in
-    let parse_name idx =
-      let idx0 = idx in
-      let idx = consume_alpha idx in
-      let name = String.sub s idx0 (idx - idx0) in
-      (name, idx)
-    in
-    let parse_column idx =
-      match s.[idx] with
-      | ':' -> idx + 1
-      | _ -> failwith "no : after named argument"
-    in
-    let parse_named idx =
-      let idx = consume_ws idx in
-      match s.[idx] with
-      | '~' ->
-          let idx = idx + 1 in
-          let name, idx = parse_name idx in
-          let idx = parse_column idx in
-          let arg, idx = parse_arg idx in
-          Some ((name, arg), idx)
-      | (exception Invalid_argument _) | _ -> None
-    in
-    let parse_semicolon idx =
-      let idx = consume_ws idx in
-      match s.[idx] with
-      | ';' -> Some ((), idx)
-      | (exception Invalid_argument _) | _ -> None
-    in
-    let parse_positional idx =
-      let idx = consume_ws idx in
-      match s.[idx] with
-      | _ -> Some (parse_arg idx)
-      | exception Invalid_argument _ -> None
-    in
-    let parse_one idx =
-      let ( let$ ) x f = match x with Some _ as x -> x | None -> f () in
-      let ( let> ) x f =
-        match x with Some (x, idx) -> Some (f x, idx) | None -> None
-      in
-      let$ () =
-        let> named = parse_named idx in
-        `Named named
-      in
-      let$ () =
-        let> () = parse_semicolon idx in
-        `Semicolon
-      in
-      let> p = parse_positional idx in
-      `Positional p
-    in
-    let parse_all = repeat parse_one in
-    let parsed, _ = parse_all 0 in
-    let unfinished_acc, parsed =
-      List.fold_left
-        (fun (current_acc, global_acc) -> function
-          | `Semicolon -> ([], List.rev current_acc :: global_acc)
-          | (`Positional _ | `Named _) as x -> (x :: current_acc, global_acc))
-        ([], []) parsed
-    in
-    let parsed = List.rev unfinished_acc :: parsed |> List.rev in
-    parsed
-    |> List.map
-       @@ List.partition_map (function
-            | `Named x -> Left x
-            | `Positional p -> Right p)
+(* We define the [Actions_] module to avoid a circular dependency: If we had
+   only one [Action] module (and not an [Actions] and an [Actions_]) then
+   [Actions] would depend on [Javascrip_api] which would depend on [Actions]. *)
 
-  let ( let+ ) x y = Result.map y x
-
-  module Smap = Map.Make (String)
-
-  type action = { named : string Smap.t; positional : string list }
-
-  let parse_string s =
-    let+ s =
-      try Ok (parse_string s)
-      with _ (* TODO: finer grain catch and better error messages *) ->
-        Error (`Msg "Failed when trying to parse argument")
-    in
-    s
-    |> List.map (fun (named, positional) ->
-           let named =
-             Smap.of_list named
-             (* TODO: warn on duplicate name *)
-           in
-           { named; positional })
-
-  let id x = Jstr.of_string ("#" ^ x)
-
-  type 'a description_named_atom = string * (string -> 'a)
-
-  type _ descr_tuple =
-    | [] : unit descr_tuple
-    | ( :: ) :
-        'a description_named_atom * 'b descr_tuple
-        -> ('a * 'b) descr_tuple
-
-  type _ output_tuple =
-    | [] : unit output_tuple
-    | ( :: ) : 'a option * 'b output_tuple -> ('a * 'b) output_tuple
-
-  let parsed_name (description_name, description_convert) action =
-    Smap.find_opt description_name action.named
-    |> Option.map description_convert
-
-  let rec parsed_names : type a. action -> a descr_tuple -> a output_tuple =
-   fun action descriptions ->
-    match descriptions with
-    | [] -> []
-    | description :: rest ->
-        parsed_name description action :: parsed_names action rest
-
-  let parse_atom ~named ~positional action =
-    let named = parsed_names action named in
-    let positional = List.map positional action.positional in
-    (named, positional)
-
-  let parse ~named ~positional s =
-    let+ parsed_string = parse_string s in
-    List.map (parse_atom ~named ~positional) parsed_string |> function
-    | [] ->
-        assert false
-        (* An empty string would be parsed as [ [[None; None; ...], []] ] *)
-    | a :: rest -> (a, rest)
-
-  let merge_positional ((([] : _ output_tuple), p), x) =
-    p @ List.concat_map (fun (([] : _ output_tuple), p) -> p) x
-
-  let require_single_action ~action_name x =
-    match x with
-    | a, rest ->
-        let () =
-          match (rest : _ list) with
-          | [] -> ()
-          | _ :: _ ->
-              Logs.warn (fun m ->
-                  m "Action %s does not support ';'-separated arguments"
-                    action_name)
-        in
-        a
-
-  let require_single_positional ~action_name (x : _ list) =
-    match x with
-    | [] -> None
-    | a :: rest ->
-        let () =
-          match rest with
-          | [] -> ()
-          | _ :: _ ->
-              Logs.warn (fun m ->
-                  m "Action %s does not support multiple arguments" action_name)
-        in
-        Some a
-
-  let duration = ("duration", Float.of_string)
-  let margin = ("margin", Float.of_string)
-end
-
-module Pause = struct
-  let do_to_root elem f =
-    let is_root elem =
-      Brr.El.class' (Jstr.v "slip") elem
-      || (Option.is_some @@ Brr.El.at (Jstr.v "pause-block") elem)
-    in
-    let rec do_rec elem =
-      if is_root elem then Undoable.return ()
-      else
-        let> () = f elem in
-        match Brr.El.parent elem with
-        | None -> Undoable.return ()
-        | Some elem -> do_rec elem
-    in
-    do_rec elem
-
-  open Undoable.Browser
-
-  let update_single elem n =
-    if n <= 0 then
-      let> () = set_at "pauseAncestorMultiplicity" None elem in
-      set_class "pauseAncestor" false elem
-    else
-      let> () =
-        set_at "pauseAncestorMultiplicity" (Some (Jstr.of_int n)) elem
-      in
-      set_class "pauseAncestor" true elem
-
-  let update elem f =
-    do_to_root elem @@ fun elem ->
-    let n =
-      match Brr.El.at (Jstr.v "pauseAncestorMultiplicity") elem with
-      | None -> 0
-      | Some n -> (
-          match Jstr.to_int n with
-          | None ->
-              Brr.Console.(
-                log [ "Error: wrong value to pauseAncestorMultiplicity:"; n ]);
-              0
-          | Some n -> n)
-    in
-    update_single elem (f n)
-
-  let setup elem =
-    let> () = set_class "pauseTarget" true elem in
-    update elem (( + ) 1)
-
+module Execute = struct
   type args = Brr.El.t list
 
-  let parse_args elem s =
-    let ( let$ ) = Fun.flip Result.map in
-    let$ x = Parse.parse ~named:[] ~positional:Parse.id s in
-    match Parse.merge_positional x with
-    | [] -> [ elem ]
-    | x -> List.filter_map Brr.El.find_first_by_selector x
+  let on = "exec-at-unpause"
+  let action_name = "exec"
+  let parse_args = Parse.parse_only_els
 
-  let do_ _window elems =
-    elems
-    |> Undoable.List.iter @@ fun elem ->
-       let> () = set_class "pauseTarget" false elem in
-       update elem (fun n -> n - 1)
-end
+  open Fut.Syntax
 
-module Move (X : sig
-  val action_name : string
-
-  val move :
-    ?duration:float ->
-    ?margin:float ->
-    Universe.Window.t ->
-    Brr.El.t ->
-    unit Undoable.t
-end) =
-struct
-  type args = {
-    margin : float option;
-    duration : float option;
-    elem : Brr.El.t;
-  }
-
-  let parse_args elem s =
-    let ( let* ) = Result.bind in
-    let* x =
-      Parse.parse ~named:[ Parse.duration; Parse.margin ] ~positional:Parse.id s
-    in
-    match Parse.require_single_action ~action_name:X.action_name x with
-    | [ duration; margin ], positional -> (
-        match
-          Parse.require_single_positional ~action_name:X.action_name positional
-        with
-        | None -> Ok { elem; duration; margin }
-        | Some positional -> (
-            match Brr.El.find_first_by_selector positional with
-            | None ->
-                Error
-                  (`Msg
-                     ("Could not find element with id"
-                    ^ Jstr.to_string positional))
-            | Some elem -> Ok { elem; duration; margin }))
-
-  let do_ window { margin; duration; elem } =
-    let margin = Option.value ~default:0. margin in
-    let duration = Option.value ~default:1. duration in
-    X.move ~margin ~duration window elem
-end
-
-module SetClass (X : sig
-  val class_ : string
-  val state : bool
-end) =
-struct
-  type args = Brr.El.t list
-
-  let parse_args elem s =
-    let ( let$ ) = Fun.flip Result.map in
-    let$ x = Parse.parse ~named:[] ~positional:Parse.id s in
-    match Parse.merge_positional x with
-    | [] -> [ elem ]
-    | x -> List.filter_map Brr.El.find_first_by_selector x
-
-  let do_ _window elems =
-    Undoable.List.iter (Undoable.Browser.set_class X.class_ X.state) elems
-end
-
-module Up = Move (struct
-  let action_name = "up"
-  let move = Universe.Move.up
-end)
-
-module Down = Move (struct
-  let action_name = "down"
-  let move = Universe.Move.down
-end)
-
-module Center = Move (struct
-  let action_name = "center"
-  let move = Universe.Move.center
-end)
-
-module Scroll = Move (struct
-  let action_name = "scroll"
-  let move = Universe.Move.scroll
-end)
-
-module Enter = struct
-  type t = { elem : Brr.El.t; coord : Universe.Coordinates.window }
-
-  let stack = Stack.create ()
-
-  include Move (struct
-    let action_name = "enter"
-
-    let move ?duration ?margin window elem =
-      let> () =
-        Undoable.Stack.push { elem; coord = Universe.State.get_coord () } stack
+  let do_ window elem =
+    try
+      let body = Jv.get (Brr.El.to_jv elem) "innerHTML" |> Jv.to_jstr in
+      Brr.Console.(log [ body ]);
+      let args = Jv.Function.[ ("slip", Fun.id) ] in
+      let f = Jv.Function.v ~body ~args in
+      let undos_ref = ref [] in
+      let arg = Javascript_api.slip window undos_ref in
+      let u = f arg in
+      let undo () =
+        try Fut.return (ignore @@ Jv.call u "undo" [||])
+        with _ ->
+          List.fold_left
+            (fun acc f ->
+              let* () = acc in
+              f ())
+            (Fut.return ()) !undos_ref
       in
-      Universe.Move.enter ?duration ?margin window elem
-  end)
+      Undoable.return ~undo ()
+    with e ->
+      Brr.Console.(
+        log
+          [ "An exception occurred when trying to execute a custom script:"; e ]);
+      Undoable.return ()
+
+  let do_ window elems = Undoable.List.iter (do_ window) elems
 end
 
-let exit window to_elem =
-  let rec exit () =
-    let coord = Undoable.Stack.peek Enter.stack in
-    match coord with
-    | None -> Undoable.return ()
-    | Some { Enter.elem; _ } when Brr.El.contains elem ~child:to_elem ->
-        Undoable.return ()
-    | Some { coord; _ } -> (
-        let> _ = Undoable.Stack.pop_opt Enter.stack in
-        match Undoable.Stack.peek Enter.stack with
-        | None -> Universe.Move.move window coord ~duration:1.0
-        | Some { Enter.elem; _ } when Brr.El.contains elem ~child:to_elem ->
-            Universe.Move.move window coord ~duration:1.0
-        | Some _ -> exit ())
-  in
-  exit ()
-
-module Unstatic = SetClass (struct
-  let class_ = "unstatic"
-  let state = true
-end)
-
-module Static = SetClass (struct
-  let class_ = "unstatic"
-  let state = false
-end)
-
-module Focus = struct
-  type args = {
-    margin : float option;
-    duration : float option;
-    elems : Brr.El.t list;
-  }
-
-  let action_name = "focus"
-
-  let parse_args elem s =
-    let ( let$ ) = Fun.flip Result.map in
-    let$ x =
-      Parse.parse ~named:[ Parse.duration; Parse.margin ] ~positional:Parse.id s
-    in
-    match Parse.require_single_action ~action_name x with
-    | [ duration; margin ], [] -> { elems = [ elem ]; duration; margin }
-    | [ duration; margin ], positional ->
-        let elems = List.filter_map Brr.El.find_first_by_selector positional in
-        { elems; duration; margin }
-
-  let do_ window { margin; duration; elems } =
-    let> () = State.Focus.push (Universe.State.get_coord ()) in
-    let margin = Option.value ~default:0. margin in
-    let duration = Option.value ~default:1. duration in
-    Universe.Move.focus ~margin ~duration window elems
-end
-
-let unfocus window () =
-  let> coord = State.Focus.pop () in
-  match coord with
-  | None -> Undoable.return ()
-  | Some coord -> Universe.Move.move window coord ~duration:1.0
-
-module Reveal = SetClass (struct
-  let class_ = "unrevealed"
-  let state = false
-end)
-
-module Unreveal = SetClass (struct
-  let class_ = "unrevealed"
-  let state = true
-end)
-
-module Emph = SetClass (struct
-  let class_ = "emphasized"
-  let state = true
-end)
-
-module Unemph = SetClass (struct
-  let class_ = "emphasized"
-  let state = false
-end)
-
-module type S = sig
-  type args
-
-  val parse_args : Brr.El.t -> string -> (args, [> `Msg of string ]) result
-  val do_ : Universe.Window.t -> args -> unit Undoable.t
-end
-
-module type Move = sig
-  type args = {
-    margin : float option;
-    duration : float option;
-    elem : Brr.El.t;
-  }
-
-  include S with type args := args
-end
-
-module type SetClass = S with type args = Brr.El.t list
+(* Note: the order is important, it's going to be applied in this order *)
+let all =
+  [
+    (module Pause : S);
+    (module Actions_.Step : S);
+    (* For some reasons, without [Actions_.], this trips (probably ocamldep or
+       its driver, dune). *)
+    (module Unstatic : S);
+    (module Static : S);
+    (module Unreveal : S);
+    (module Reveal : S);
+    (module Unfocus : S);
+    (module Center : S);
+    (module Enter : S);
+    (module Down : S);
+    (module Focus : S);
+    (module Up : S);
+    (module Scroll : S);
+    (module Emph : S);
+    (module Unemph : S);
+    (module Execute : S);
+  ]

--- a/src/engine/step/actions.mli
+++ b/src/engine/step/actions.mli
@@ -1,5 +1,8 @@
-val setup_pause : Brr.El.t -> unit Undoable.t
-val pause : Brr.El.t -> unit Undoable.t
+module Pause : sig
+  val setup : Brr.El.t -> unit Undoable.t
+  val do_ : Brr.El.t -> unit Undoable.t
+end
+
 val up : Universe.Window.t -> Brr.El.t -> unit Undoable.t
 val down : Universe.Window.t -> Brr.El.t -> unit Undoable.t
 val center : Universe.Window.t -> Brr.El.t -> unit Undoable.t

--- a/src/engine/step/actions.mli
+++ b/src/engine/step/actions.mli
@@ -1,11 +1,3 @@
-module Pause : sig
-  type args = Brr.El.t
-
-  val parse_args : Brr.El.t -> string -> (args list, [> `Msg of string ]) result
-  val setup : Brr.El.t -> unit Undoable.t
-  val do_ : Brr.El.t -> unit Undoable.t
-end
-
 module type S = sig
   type args
 
@@ -13,26 +5,44 @@ module type S = sig
   val do_ : Universe.Window.t -> args -> unit Undoable.t
 end
 
+module Pause : sig
+  type args = Brr.El.t list
+
+  include S with type args := args
+
+  val setup : Brr.El.t -> unit Undoable.t
+end
+
 module type Move = sig
-  type args = { margin : float option; delay : float option; elem : Brr.El.t }
+  type args = {
+    margin : float option;
+    duration : float option;
+    elem : Brr.El.t;
+  }
 
   include S with type args := args
 end
+
+module type SetClass = S with type args = Brr.El.t list
 
 module Up : Move
 module Down : Move
 module Center : Move
 module Scroll : Move
+module Enter : Move
+module Unstatic : SetClass
+module Static : SetClass
+module Reveal : SetClass
+module Unreveal : SetClass
+module Emph : SetClass
+module Unemph : SetClass
 
-val enter : Universe.Window.t -> Brr.El.t -> unit Undoable.t
 val exit : Universe.Window.t -> Brr.El.t -> unit Undoable.t
-val unstatic : Brr.El.t list -> unit Undoable.t
-val static : Brr.El.t list -> unit Undoable.t
 
 module Focus : sig
   type args = {
     margin : float option;
-    delay : float option;
+    duration : float option;
     elems : Brr.El.t list;
   }
 
@@ -40,7 +50,3 @@ module Focus : sig
 end
 
 val unfocus : Universe.Window.t -> unit -> unit Undoable.t
-val reveal : Brr.El.t list -> unit Undoable.t
-val unreveal : Brr.El.t list -> unit Undoable.t
-val emph : Brr.El.t list -> unit Undoable.t
-val unemph : Brr.El.t list -> unit Undoable.t

--- a/src/engine/step/actions.mli
+++ b/src/engine/step/actions.mli
@@ -7,14 +7,17 @@ val enter : Universe.Window.t -> Brr.El.t -> unit Undoable.t
 val exit : Universe.Window.t -> Brr.El.t -> unit Undoable.t
 val unstatic : Brr.El.t list -> unit Undoable.t
 val static : Brr.El.t list -> unit Undoable.t
-val parse_focus : Brr.El.t -> string -> float * float * Brr.El.t list
 
-val focus :
-  Universe.Window.t ->
-  margin:float ->
-  delay:float ->
-  Brr.El.t list ->
-  unit Undoable.t
+module Focus : sig
+  type args = {
+    margin : float option;
+    delay : float option;
+    elems : Brr.El.t list;
+  }
+
+  val parse_args : Brr.El.t -> string -> (args, [> `Msg of string ]) result
+  val do_ : Universe.Window.t -> args -> unit Undoable.t
+end
 
 val unfocus : Universe.Window.t -> unit -> unit Undoable.t
 val reveal : Brr.El.t list -> unit Undoable.t

--- a/src/engine/step/actions.mli
+++ b/src/engine/step/actions.mli
@@ -1,11 +1,29 @@
 module Pause : sig
+  type args = Brr.El.t
+
+  val parse_args : Brr.El.t -> string -> (args list, [> `Msg of string ]) result
   val setup : Brr.El.t -> unit Undoable.t
   val do_ : Brr.El.t -> unit Undoable.t
 end
 
-val up : Universe.Window.t -> Brr.El.t -> unit Undoable.t
-val down : Universe.Window.t -> Brr.El.t -> unit Undoable.t
-val center : Universe.Window.t -> Brr.El.t -> unit Undoable.t
+module type S = sig
+  type args
+
+  val parse_args : Brr.El.t -> string -> (args, [> `Msg of string ]) result
+  val do_ : Universe.Window.t -> args -> unit Undoable.t
+end
+
+module type Move = sig
+  type args = { margin : float option; delay : float option; elem : Brr.El.t }
+
+  include S with type args := args
+end
+
+module Up : Move
+module Down : Move
+module Center : Move
+module Scroll : Move
+
 val enter : Universe.Window.t -> Brr.El.t -> unit Undoable.t
 val exit : Universe.Window.t -> Brr.El.t -> unit Undoable.t
 val unstatic : Brr.El.t list -> unit Undoable.t
@@ -18,8 +36,7 @@ module Focus : sig
     elems : Brr.El.t list;
   }
 
-  val parse_args : Brr.El.t -> string -> (args, [> `Msg of string ]) result
-  val do_ : Universe.Window.t -> args -> unit Undoable.t
+  include S with type args := args
 end
 
 val unfocus : Universe.Window.t -> unit -> unit Undoable.t
@@ -27,4 +44,3 @@ val reveal : Brr.El.t list -> unit Undoable.t
 val unreveal : Brr.El.t list -> unit Undoable.t
 val emph : Brr.El.t list -> unit Undoable.t
 val unemph : Brr.El.t list -> unit Undoable.t
-val scroll : Universe.Window.t -> Brr.El.t -> unit Undoable.t

--- a/src/engine/step/actions.mli
+++ b/src/engine/step/actions.mli
@@ -7,7 +7,15 @@ val enter : Universe.Window.t -> Brr.El.t -> unit Undoable.t
 val exit : Universe.Window.t -> Brr.El.t -> unit Undoable.t
 val unstatic : Brr.El.t list -> unit Undoable.t
 val static : Brr.El.t list -> unit Undoable.t
-val focus : Universe.Window.t -> Brr.El.t list -> unit Undoable.t
+val parse_focus : Brr.El.t -> string -> float * float * Brr.El.t list
+
+val focus :
+  Universe.Window.t ->
+  margin:float ->
+  delay:float ->
+  Brr.El.t list ->
+  unit Undoable.t
+
 val unfocus : Universe.Window.t -> unit -> unit Undoable.t
 val reveal : Brr.El.t list -> unit Undoable.t
 val unreveal : Brr.El.t list -> unit Undoable.t

--- a/src/engine/step/actions.mli
+++ b/src/engine/step/actions.mli
@@ -1,6 +1,8 @@
 module type S = sig
   type args
 
+  val on : string
+  val action_name : string
   val parse_args : Brr.El.t -> string -> (args, [> `Msg of string ]) result
   val do_ : Universe.Window.t -> args -> unit Undoable.t
 end
@@ -10,7 +12,7 @@ module Pause : sig
 
   include S with type args := args
 
-  val setup : Brr.El.t -> unit Undoable.t
+  val setup : Brr.El.t list -> unit Undoable.t
 end
 
 module type Move = sig
@@ -36,6 +38,7 @@ module Reveal : SetClass
 module Unreveal : SetClass
 module Emph : SetClass
 module Unemph : SetClass
+module Step : S with type args = unit
 
 val exit : Universe.Window.t -> Brr.El.t -> unit Undoable.t
 
@@ -49,4 +52,7 @@ module Focus : sig
   include S with type args := args
 end
 
-val unfocus : Universe.Window.t -> unit -> unit Undoable.t
+module Unfocus : S with type args = unit
+module Execute : S with type args = Brr.El.t list
+
+val all : (module S) list

--- a/src/engine/step/actions_.ml
+++ b/src/engine/step/actions_.ml
@@ -125,7 +125,15 @@ module Parse = struct
 
   let ( let+ ) x y = Result.map y x
 
-  module Smap = Map.Make (String)
+  module Smap_ = Map.Make (String)
+
+  module Smap = struct
+    include Smap_
+
+    (* of_list has only been added in 5.1. Implementation taken from the OCaml
+       stdlib. *)
+    let of_list bs = List.fold_left (fun m (k, v) -> add k v m) empty bs
+  end
 
   type action = { named : string Smap.t; positional : string list }
 

--- a/src/engine/step/actions_.ml
+++ b/src/engine/step/actions_.ml
@@ -1,0 +1,531 @@
+open Undoable.Syntax
+
+(* We define the [Actions_] module to avoid a circular dependency: If we had
+   only one [Action] module (and not an [Actions] and an [Actions_]) then
+   [Actions] would depend on [Javascrip_api] which would depend on [Actions]. *)
+
+module Parse = struct
+  let parse_string s =
+    let is_ws idx = match s.[idx] with '\n' | ' ' -> true | _ -> false in
+    let is_alpha idx =
+      let c = s.[idx] in
+      ('a' <= c && c <= 'z')
+      || ('A' <= c && c <= 'Z')
+      || ('0' <= c && c <= '9')
+      || c = '_'
+    in
+    let rec consume_ws idx =
+      if idx >= String.length s then idx
+      else if is_ws idx then consume_ws (idx + 1)
+      else idx
+    in
+    let rec consume_non_ws idx =
+      if idx >= String.length s then idx
+      else if not (is_ws idx) then consume_non_ws (idx + 1)
+      else idx
+    in
+    let rec consume_alpha idx =
+      if idx >= String.length s then idx
+      else if is_alpha idx then consume_alpha (idx + 1)
+      else idx
+    in
+    let quoted_string idx =
+      let rec take_inside_quoted_string acc idx =
+        match s.[idx] with
+        | '"' -> (acc |> List.rev |> List.to_seq |> String.of_seq, idx + 1)
+        | '\\' -> take_inside_quoted_string (s.[idx + 1] :: acc) (idx + 2)
+        | _ -> take_inside_quoted_string (s.[idx] :: acc) (idx + 1)
+      in
+      take_inside_quoted_string [] idx
+    in
+    let parse_unquoted_string idx =
+      let idx0 = idx in
+      let idx = consume_non_ws idx in
+      let arg = String.sub s idx0 (idx - idx0) in
+      (arg, idx)
+    in
+    let parse_arg idx =
+      match s.[idx] with
+      | '"' -> quoted_string (idx + 1)
+      | _ -> parse_unquoted_string idx
+    in
+    let repeat parser idx =
+      let rec do_ acc idx =
+        match parser idx with
+        | None -> (List.rev acc, idx)
+        | Some (x, idx) -> do_ (x :: acc) idx
+      in
+      do_ [] idx
+    in
+    let parse_name idx =
+      let idx0 = idx in
+      let idx = consume_alpha idx in
+      let name = String.sub s idx0 (idx - idx0) in
+      (name, idx)
+    in
+    let parse_column idx =
+      match s.[idx] with
+      | ':' -> idx + 1
+      | _ -> failwith "no : after named argument"
+    in
+    let parse_named idx =
+      let idx = consume_ws idx in
+      match s.[idx] with
+      | '~' ->
+          let idx = idx + 1 in
+          let name, idx = parse_name idx in
+          let idx = parse_column idx in
+          let arg, idx = parse_arg idx in
+          Some ((name, arg), idx)
+      | (exception Invalid_argument _) | _ -> None
+    in
+    let parse_semicolon idx =
+      let idx = consume_ws idx in
+      match s.[idx] with
+      | ';' -> Some ((), idx)
+      | (exception Invalid_argument _) | _ -> None
+    in
+    let parse_positional idx =
+      let idx = consume_ws idx in
+      match s.[idx] with
+      | _ -> Some (parse_arg idx)
+      | exception Invalid_argument _ -> None
+    in
+    let parse_one idx =
+      let ( let$ ) x f = match x with Some _ as x -> x | None -> f () in
+      let ( let> ) x f =
+        match x with Some (x, idx) -> Some (f x, idx) | None -> None
+      in
+      let$ () =
+        let> named = parse_named idx in
+        `Named named
+      in
+      let$ () =
+        let> () = parse_semicolon idx in
+        `Semicolon
+      in
+      let> p = parse_positional idx in
+      `Positional p
+    in
+    let parse_all = repeat parse_one in
+    let parsed, _ = parse_all 0 in
+    let unfinished_acc, parsed =
+      List.fold_left
+        (fun (current_acc, global_acc) -> function
+          | `Semicolon -> ([], List.rev current_acc :: global_acc)
+          | (`Positional _ | `Named _) as x -> (x :: current_acc, global_acc))
+        ([], []) parsed
+    in
+    let parsed = List.rev unfinished_acc :: parsed |> List.rev in
+    parsed
+    |> List.map
+       @@ List.partition_map (function
+            | `Named x -> Left x
+            | `Positional p -> Right p)
+
+  let ( let+ ) x y = Result.map y x
+
+  module Smap = Map.Make (String)
+
+  type action = { named : string Smap.t; positional : string list }
+
+  let parse_string s =
+    let+ s =
+      try Ok (parse_string s)
+      with _ (* TODO: finer grain catch and better error messages *) ->
+        Error (`Msg "Failed when trying to parse argument")
+    in
+    s
+    |> List.map (fun (named, positional) ->
+           let named =
+             Smap.of_list named
+             (* TODO: warn on duplicate name *)
+           in
+           { named; positional })
+
+  let id x = Jstr.of_string ("#" ^ x)
+
+  type 'a description_named_atom = string * (string -> 'a)
+
+  type _ descr_tuple =
+    | [] : unit descr_tuple
+    | ( :: ) :
+        'a description_named_atom * 'b descr_tuple
+        -> ('a * 'b) descr_tuple
+
+  type _ output_tuple =
+    | [] : unit output_tuple
+    | ( :: ) : 'a option * 'b output_tuple -> ('a * 'b) output_tuple
+
+  let parsed_name (description_name, description_convert) action =
+    Smap.find_opt description_name action.named
+    |> Option.map description_convert
+
+  let rec parsed_names : type a. action -> a descr_tuple -> a output_tuple =
+   fun action descriptions ->
+    match descriptions with
+    | [] -> []
+    | description :: rest ->
+        parsed_name description action :: parsed_names action rest
+
+  let parse_atom ~named ~positional action =
+    let named = parsed_names action named in
+    let positional = List.map positional action.positional in
+    (named, positional)
+
+  let parse ~named ~positional s =
+    let+ parsed_string = parse_string s in
+    List.map (parse_atom ~named ~positional) parsed_string |> function
+    | [] ->
+        assert false
+        (* An empty string would be parsed as [ [[None; None; ...], []] ] *)
+    | a :: rest -> (a, rest)
+
+  let merge_positional ((([] : _ output_tuple), p), x) =
+    p @ List.concat_map (fun (([] : _ output_tuple), p) -> p) x
+
+  let require_single_action ~action_name x =
+    match x with
+    | a, rest ->
+        let () =
+          match (rest : _ list) with
+          | [] -> ()
+          | _ :: _ ->
+              Logs.warn (fun m ->
+                  m "Action %s does not support ';'-separated arguments"
+                    action_name)
+        in
+        a
+
+  let require_single_positional ~action_name (x : _ list) =
+    match x with
+    | [] -> None
+    | a :: rest ->
+        let () =
+          match rest with
+          | [] -> ()
+          | _ :: _ ->
+              Logs.warn (fun m ->
+                  m "Action %s does not support multiple arguments" action_name)
+        in
+        Some a
+
+  let no_args ~action_name _elem s =
+    let ( let$ ) = Fun.flip Result.map in
+    let$ x = parse ~named:[] ~positional:id s in
+    match x with
+    | ([], []), [] -> ()
+    | _ ->
+        Logs.warn (fun m ->
+            m "The %s action does not accept any argument" action_name)
+
+  let parse_only_els elem s =
+    let ( let$ ) = Fun.flip Result.map in
+    let$ x = parse ~named:[] ~positional:id s in
+    match merge_positional x with
+    | [] -> List.[ elem ]
+    | x -> List.filter_map Brr.El.find_first_by_selector x
+
+  let duration = ("duration", Float.of_string)
+  let margin = ("margin", Float.of_string)
+end
+
+module type S = sig
+  type args
+
+  val on : string
+  val action_name : string
+  val parse_args : Brr.El.t -> string -> (args, [> `Msg of string ]) result
+  val do_ : Universe.Window.t -> args -> unit Undoable.t
+end
+
+module type Move = sig
+  type args = {
+    margin : float option;
+    duration : float option;
+    elem : Brr.El.t;
+  }
+
+  include S with type args := args
+end
+
+module type SetClass = S with type args = Brr.El.t list
+
+module Pause = struct
+  let on = "pause"
+  let action_name = "pause"
+
+  let do_to_root elem f =
+    let is_root elem =
+      Brr.El.class' (Jstr.v "slip") elem
+      || (Option.is_some @@ Brr.El.at (Jstr.v "pause-block") elem)
+    in
+    let rec do_rec elem =
+      if is_root elem then Undoable.return ()
+      else
+        let> () = f elem in
+        match Brr.El.parent elem with
+        | None -> Undoable.return ()
+        | Some elem -> do_rec elem
+    in
+    do_rec elem
+
+  open Undoable.Browser
+
+  let update_single elem n =
+    if n <= 0 then
+      let> () = set_at "pauseAncestorMultiplicity" None elem in
+      set_class "pauseAncestor" false elem
+    else
+      let> () =
+        set_at "pauseAncestorMultiplicity" (Some (Jstr.of_int n)) elem
+      in
+      set_class "pauseAncestor" true elem
+
+  let update elem f =
+    do_to_root elem @@ fun elem ->
+    let n =
+      match Brr.El.at (Jstr.v "pauseAncestorMultiplicity") elem with
+      | None -> 0
+      | Some n -> (
+          match Jstr.to_int n with
+          | None ->
+              Brr.Console.(
+                log [ "Error: wrong value to pauseAncestorMultiplicity:"; n ]);
+              0
+          | Some n -> n)
+    in
+    update_single elem (f n)
+
+  let setup elem =
+    let> () = set_class "pauseTarget" true elem in
+    update elem (( + ) 1)
+
+  let setup elems = Undoable.List.iter setup elems
+
+  type args = Brr.El.t list
+
+  let parse_args = Parse.parse_only_els
+
+  let do_ _window elems =
+    elems
+    |> Undoable.List.iter @@ fun elem ->
+       let> () = set_class "pauseTarget" false elem in
+       update elem (fun n -> n - 1)
+end
+
+module Move (X : sig
+  val on : string
+  val action_name : string
+
+  val move :
+    ?duration:float ->
+    ?margin:float ->
+    Universe.Window.t ->
+    Brr.El.t ->
+    unit Undoable.t
+end) =
+struct
+  let on = X.on
+  let action_name = X.action_name
+
+  type args = {
+    margin : float option;
+    duration : float option;
+    elem : Brr.El.t;
+  }
+
+  let parse_args elem s =
+    let ( let* ) = Result.bind in
+    let* x =
+      Parse.parse ~named:[ Parse.duration; Parse.margin ] ~positional:Parse.id s
+    in
+    match Parse.require_single_action ~action_name:X.action_name x with
+    | [ duration; margin ], positional -> (
+        match
+          Parse.require_single_positional ~action_name:X.action_name positional
+        with
+        | None -> Ok { elem; duration; margin }
+        | Some positional -> (
+            match Brr.El.find_first_by_selector positional with
+            | None ->
+                Error
+                  (`Msg
+                     ("Could not find element with id"
+                    ^ Jstr.to_string positional))
+            | Some elem -> Ok { elem; duration; margin }))
+
+  let do_ window { margin; duration; elem } =
+    let margin = Option.value ~default:0. margin in
+    let duration = Option.value ~default:1. duration in
+    X.move ~margin ~duration window elem
+end
+
+module SetClass (X : sig
+  val on : string
+  val action_name : string
+  val class_ : string
+  val state : bool
+end) =
+struct
+  let on = X.on
+  let action_name = X.action_name
+
+  type args = Brr.El.t list
+
+  let parse_args = Parse.parse_only_els
+
+  let do_ _window elems =
+    Undoable.List.iter (Undoable.Browser.set_class X.class_ X.state) elems
+end
+
+module Up = Move (struct
+  let on = "up-at-unpause"
+  let action_name = "up"
+  let move = Universe.Move.up
+end)
+
+module Down = Move (struct
+  let on = "down-at-unpause"
+  let action_name = "down"
+  let move = Universe.Move.down
+end)
+
+module Center = Move (struct
+  let on = "center-at-unpause"
+  let action_name = "center"
+  let move = Universe.Move.center
+end)
+
+module Scroll = Move (struct
+  let on = "scroll-at-unpause"
+  let action_name = "scroll"
+  let move = Universe.Move.scroll
+end)
+
+module Enter = struct
+  type t = { elem : Brr.El.t; coord : Universe.Coordinates.window }
+
+  let stack = Stack.create ()
+
+  include Move (struct
+    let on = "enter-at-unpause"
+    let action_name = "enter"
+
+    let move ?duration ?margin window elem =
+      let> () =
+        Undoable.Stack.push { elem; coord = Universe.State.get_coord () } stack
+      in
+      Universe.Move.enter ?duration ?margin window elem
+  end)
+end
+
+let exit window to_elem =
+  let rec exit () =
+    let coord = Undoable.Stack.peek Enter.stack in
+    match coord with
+    | None -> Undoable.return ()
+    | Some { Enter.elem; _ } when Brr.El.contains elem ~child:to_elem ->
+        Undoable.return ()
+    | Some { coord; _ } -> (
+        let> _ = Undoable.Stack.pop_opt Enter.stack in
+        match Undoable.Stack.peek Enter.stack with
+        | None -> Universe.Move.move window coord ~duration:1.0
+        | Some { Enter.elem; _ } when Brr.El.contains elem ~child:to_elem ->
+            Universe.Move.move window coord ~duration:1.0
+        | Some _ -> exit ())
+  in
+  exit ()
+
+module Unstatic = SetClass (struct
+  let on = "unstatic-at-unpause"
+  let action_name = "unstatic"
+  let class_ = "unstatic"
+  let state = true
+end)
+
+module Static = SetClass (struct
+  let on = "static-at-unpause"
+  let action_name = "static"
+  let class_ = "unstatic"
+  let state = false
+end)
+
+module Focus = struct
+  type args = {
+    margin : float option;
+    duration : float option;
+    elems : Brr.El.t list;
+  }
+
+  let on = "focus-at-unpause"
+  let action_name = "focus"
+
+  let parse_args elem s =
+    let ( let$ ) = Fun.flip Result.map in
+    let$ x =
+      Parse.parse ~named:[ Parse.duration; Parse.margin ] ~positional:Parse.id s
+    in
+    match Parse.require_single_action ~action_name x with
+    | [ duration; margin ], [] -> { elems = [ elem ]; duration; margin }
+    | [ duration; margin ], positional ->
+        let elems = List.filter_map Brr.El.find_first_by_selector positional in
+        { elems; duration; margin }
+
+  let do_ window { margin; duration; elems } =
+    let> () = State.Focus.push (Universe.State.get_coord ()) in
+    let margin = Option.value ~default:0. margin in
+    let duration = Option.value ~default:1. duration in
+    Universe.Move.focus ~margin ~duration window elems
+end
+
+module Unfocus = struct
+  type args = unit
+
+  let on = "unfocus-at-unpause"
+  let action_name = "unfocus"
+  let parse_args elem s = Parse.no_args ~action_name elem s
+
+  let do_ window () =
+    let> coord = State.Focus.pop () in
+    match coord with
+    | None -> Undoable.return ()
+    | Some coord -> Universe.Move.move window coord ~duration:1.0
+end
+
+module Reveal = SetClass (struct
+  let on = "reveal-at-unpause"
+  let action_name = "reveal"
+  let class_ = "unrevealed"
+  let state = false
+end)
+
+module Unreveal = SetClass (struct
+  let on = "unreveal-at-unpause"
+  let action_name = "unreveal"
+  let class_ = "unrevealed"
+  let state = true
+end)
+
+module Emph = SetClass (struct
+  let on = "emph-at-unpause"
+  let action_name = "emph"
+  let class_ = "emphasized"
+  let state = true
+end)
+
+module Unemph = SetClass (struct
+  let on = "unemph-at-unpause"
+  let action_name = "unemph"
+  let class_ = "emphasized"
+  let state = false
+end)
+
+module Step = struct
+  type args = unit
+
+  let on = "step"
+  let action_name = "step"
+  let parse_args elem s = Parse.no_args ~action_name elem s
+  let do_ _ _ = Undoable.return ()
+end

--- a/src/engine/step/dune
+++ b/src/engine/step/dune
@@ -1,3 +1,3 @@
 (library
  (name step)
- (libraries undoable universe communication))
+ (libraries undoable universe communication logs))

--- a/src/engine/step/javascript_api.ml
+++ b/src/engine/step/javascript_api.ml
@@ -1,5 +1,10 @@
 open Fut.Syntax
 
+(* We use the [Actions_] module to avoid a circular dependency: If we had only
+   one [Action] module (and not an [Actions] and an [Actions_]) then [Actions]
+   would depend on [Javascrip_api] which would depend on [Actions]. *)
+module Actions = Actions_
+
 let register_undo undos_ref f =
   let res =
     let+ (), undo = f () in
@@ -36,7 +41,7 @@ let focus window undos_ref =
   register_undo undos_ref @@ fun () ->
   Actions.Focus.do_ window { duration; margin; elems }
 
-let unfocus window = one_arg (fun _ -> ()) (Actions.unfocus window)
+let unfocus window = one_arg (fun _ -> ()) (Actions.Unfocus.do_ window)
 
 let class_setter (module X : Actions.SetClass) window undos_ref =
   Jv.callback ~arity:1 @@ fun elems ->

--- a/src/engine/step/javascript_api.ml
+++ b/src/engine/step/javascript_api.ml
@@ -19,7 +19,14 @@ let up window = one_elem (Actions.up window)
 let center window = one_elem (Actions.center window)
 let down window = one_elem (Actions.down window)
 let scroll window = one_elem (Actions.scroll window)
-let focus window = one_elem_list (Actions.focus window)
+
+let focus window undos_ref =
+  Jv.callback ~arity:3 @@ fun elems delay margin ->
+  let elems = (Jv.to_list Brr.El.of_jv) elems
+  and delay = Jv.to_float delay
+  and margin = Jv.to_float margin in
+  register_undo undos_ref @@ fun () -> Actions.focus window ~delay ~margin elems
+
 let unfocus window = one_arg (fun _ -> ()) (Actions.unfocus window)
 let static = one_elem_list Actions.static
 let unstatic = one_elem_list Actions.unstatic

--- a/src/engine/step/javascript_api.ml
+++ b/src/engine/step/javascript_api.ml
@@ -23,9 +23,10 @@ let scroll window = one_elem (Actions.scroll window)
 let focus window undos_ref =
   Jv.callback ~arity:3 @@ fun elems delay margin ->
   let elems = (Jv.to_list Brr.El.of_jv) elems
-  and delay = Jv.to_float delay
-  and margin = Jv.to_float margin in
-  register_undo undos_ref @@ fun () -> Actions.focus window ~delay ~margin elems
+  and delay = Jv.to_option Jv.to_float delay
+  and margin = Jv.to_option Jv.to_float margin in
+  register_undo undos_ref @@ fun () ->
+  Actions.Focus.do_ window { delay; margin; elems }
 
 let unfocus window = one_arg (fun _ -> ()) (Actions.unfocus window)
 let static = one_elem_list Actions.static

--- a/src/engine/step/javascript_api.ml
+++ b/src/engine/step/javascript_api.ml
@@ -13,12 +13,20 @@ let one_arg conv action undos_ref =
   let elem = conv elem in
   register_undo undos_ref @@ fun () -> action elem
 
-let one_elem action = one_arg Brr.El.of_jv action
+(* let one_elem action = one_arg Brr.El.of_jv action *)
 let one_elem_list action = one_arg (Jv.to_list Brr.El.of_jv) action
-let up window = one_elem (Actions.up window)
-let center window = one_elem (Actions.center window)
-let down window = one_elem (Actions.down window)
-let scroll window = one_elem (Actions.scroll window)
+
+let move (module X : Actions.Move) window undos_ref =
+  Jv.callback ~arity:3 @@ fun elems delay margin ->
+  let elem = Brr.El.of_jv elems
+  and delay = Jv.to_option Jv.to_float delay
+  and margin = Jv.to_option Jv.to_float margin in
+  register_undo undos_ref @@ fun () -> X.do_ window X.{ delay; margin; elem }
+
+let up = move (module Actions.Up)
+let down = move (module Actions.Down)
+let center = move (module Actions.Center)
+let scroll = move (module Actions.Scroll)
 
 let focus window undos_ref =
   Jv.callback ~arity:3 @@ fun elems delay margin ->

--- a/src/engine/universe/move.ml
+++ b/src/engine/universe/move.ml
@@ -9,13 +9,13 @@ open struct
   module Console = Brr.Console
 end
 
-let move window target ~delay =
+let move window target ~duration =
   let old_coordinate = State.get_coord () in
-  let+ () = move_pure window target ~delay in
-  let undo () = move_pure window old_coordinate ~delay in
+  let+ () = move_pure window target ~duration in
+  let undo () = move_pure window old_coordinate ~duration in
   ((), undo)
 
-let move_relative ?(x = 0.) ?(y = 0.) ?(scale = 1.) window ~delay =
+let move_relative ?(x = 0.) ?(y = 0.) ?(scale = 1.) window ~duration =
   let coord = State.get_coord () in
   let dest =
     {
@@ -24,59 +24,60 @@ let move_relative ?(x = 0.) ?(y = 0.) ?(scale = 1.) window ~delay =
       scale = coord.scale *. scale;
     }
   in
-  move window dest ~delay
+  move window dest ~duration
 
-let move_relative_pure ?(x = 0.) ?(y = 0.) ?(scale = 1.) window ~delay =
-  move_relative ~x ~y ~scale window ~delay |> Undoable.discard
+let move_relative_pure ?(x = 0.) ?(y = 0.) ?(scale = 1.) window ~duration =
+  move_relative ~x ~y ~scale window ~duration |> Undoable.discard
 
 let add_margin margin (c : Coordinates.element) =
   { c with width = c.width +. margin; height = c.height +. margin }
 
-let focus ?(delay = 1.) ?(margin = 0.) window elems =
+let focus ?(duration = 1.) ?(margin = 0.) window elems =
   let coords_e = List.map (Coord_computation.elem window) elems in
   let coords_e = List.map (add_margin margin) coords_e in
   let current = State.get_coord () in
   let coords_w = Coord_computation.Window.focus ~current coords_e in
-  move window coords_w ~delay
+  move window coords_w ~duration
 
 let focus_pure ?margin window elem =
   focus ?margin window elem |> Undoable.discard
 
-let enter window elem =
+let enter ?(duration = 1.) ?(margin = 0.) window elem =
   let coords_e = Coord_computation.elem window elem in
+  let coords_e = add_margin margin coords_e in
   let coords_w = Coord_computation.Window.enter coords_e in
-  move window coords_w ~delay:1.
+  move window coords_w ~duration
 
-let up ?(delay = 1.) ?(margin = 0.) window elem =
+let up ?(duration = 1.) ?(margin = 0.) window elem =
   let coords_e = Coord_computation.elem window elem in
   let coords_e = add_margin margin coords_e in
   let current = State.get_coord () in
   let coords_w = Coord_computation.Window.up ~current coords_e in
-  move window coords_w ~delay
+  move window coords_w ~duration
 
-let down ?(delay = 1.) ?(margin = 0.) window elem =
+let down ?(duration = 1.) ?(margin = 0.) window elem =
   let coords_e = Coord_computation.elem window elem in
   let coords_e = add_margin margin coords_e in
   let current = State.get_coord () in
   let coords_w = Coord_computation.Window.down ~current coords_e in
-  move window coords_w ~delay
+  move window coords_w ~duration
 
-let center ?(delay = 1.) ?(margin = 0.) window elem =
+let center ?(duration = 1.) ?(margin = 0.) window elem =
   let coords_e = Coord_computation.elem window elem in
   let coords_e = add_margin margin coords_e in
   let current = State.get_coord () in
   let coords_w = Coord_computation.Window.center ~current coords_e in
-  move window coords_w ~delay
+  move window coords_w ~duration
 
-let scroll ?(delay = 1.) ?(margin = 0.) window elem =
+let scroll ?(duration = 1.) ?(margin = 0.) window elem =
   let coords_e = Coord_computation.elem window elem in
   let current = State.get_coord () in
   if
     coords_e.y -. (coords_e.height /. 2.)
     < current.y -. (Constants.height () /. 2. *. current.scale)
-  then up window elem ~margin ~delay
+  then up window elem ~margin ~duration
   else if
     coords_e.y +. (coords_e.height /. 2.)
     > current.y +. (Constants.height () /. 2. *. current.scale)
-  then down window elem ~margin ~delay
+  then down window elem ~margin ~duration
   else Undoable.return ()

--- a/src/engine/universe/move.ml
+++ b/src/engine/universe/move.ml
@@ -29,14 +29,12 @@ let move_relative ?(x = 0.) ?(y = 0.) ?(scale = 1.) window ~delay =
 let move_relative_pure ?(x = 0.) ?(y = 0.) ?(scale = 1.) window ~delay =
   move_relative ~x ~y ~scale window ~delay |> Undoable.discard
 
+let add_margin margin (c : Coordinates.element) =
+  { c with width = c.width +. margin; height = c.height +. margin }
+
 let focus ?(delay = 1.) ?(margin = 0.) window elems =
   let coords_e = List.map (Coord_computation.elem window) elems in
-  let coords_e =
-    List.map
-      (fun (c : Coordinates.element) ->
-        { c with width = c.width +. margin; height = c.height +. margin })
-      coords_e
-  in
+  let coords_e = List.map (add_margin margin) coords_e in
   let current = State.get_coord () in
   let coords_w = Coord_computation.Window.focus ~current coords_e in
   move window coords_w ~delay
@@ -49,33 +47,36 @@ let enter window elem =
   let coords_w = Coord_computation.Window.enter coords_e in
   move window coords_w ~delay:1.
 
-let up window elem =
+let up ?(delay = 1.) ?(margin = 0.) window elem =
   let coords_e = Coord_computation.elem window elem in
+  let coords_e = add_margin margin coords_e in
   let current = State.get_coord () in
   let coords_w = Coord_computation.Window.up ~current coords_e in
-  move window coords_w ~delay:1.
+  move window coords_w ~delay
 
-let down window elem =
+let down ?(delay = 1.) ?(margin = 0.) window elem =
   let coords_e = Coord_computation.elem window elem in
+  let coords_e = add_margin margin coords_e in
   let current = State.get_coord () in
   let coords_w = Coord_computation.Window.down ~current coords_e in
-  move window coords_w ~delay:1.
+  move window coords_w ~delay
 
-let center window elem =
+let center ?(delay = 1.) ?(margin = 0.) window elem =
   let coords_e = Coord_computation.elem window elem in
+  let coords_e = add_margin margin coords_e in
   let current = State.get_coord () in
   let coords_w = Coord_computation.Window.center ~current coords_e in
-  move window coords_w ~delay:1.
+  move window coords_w ~delay
 
-let scroll window elem =
+let scroll ?(delay = 1.) ?(margin = 0.) window elem =
   let coords_e = Coord_computation.elem window elem in
   let current = State.get_coord () in
   if
     coords_e.y -. (coords_e.height /. 2.)
     < current.y -. (Constants.height () /. 2. *. current.scale)
-  then up window elem
+  then up window elem ~margin ~delay
   else if
     coords_e.y +. (coords_e.height /. 2.)
     > current.y +. (Constants.height () /. 2. *. current.scale)
-  then down window elem
+  then down window elem ~margin ~delay
   else Undoable.return ()

--- a/src/engine/universe/move.ml
+++ b/src/engine/universe/move.ml
@@ -29,7 +29,7 @@ let move_relative ?(x = 0.) ?(y = 0.) ?(scale = 1.) window ~delay =
 let move_relative_pure ?(x = 0.) ?(y = 0.) ?(scale = 1.) window ~delay =
   move_relative ~x ~y ~scale window ~delay |> Undoable.discard
 
-let focus ?(margin = 0.) window elems =
+let focus ?(delay = 1.) ?(margin = 0.) window elems =
   let coords_e = List.map (Coord_computation.elem window) elems in
   let coords_e =
     List.map
@@ -39,7 +39,7 @@ let focus ?(margin = 0.) window elems =
   in
   let current = State.get_coord () in
   let coords_w = Coord_computation.Window.focus ~current coords_e in
-  move window coords_w ~delay:1.
+  move window coords_w ~delay
 
 let focus_pure ?margin window elem =
   focus ?margin window elem |> Undoable.discard

--- a/src/engine/universe/move.mli
+++ b/src/engine/universe/move.mli
@@ -1,31 +1,41 @@
-val move : Window.t -> Coordinates.window -> delay:float -> unit Undoable.t
+val move : Window.t -> Coordinates.window -> duration:float -> unit Undoable.t
 
 val move_relative_pure :
-  ?x:float -> ?y:float -> ?scale:float -> Window.t -> delay:float -> unit Fut.t
+  ?x:float ->
+  ?y:float ->
+  ?scale:float ->
+  Window.t ->
+  duration:float ->
+  unit Fut.t
 
 val move_relative :
   ?x:float ->
   ?y:float ->
   ?scale:float ->
   Window.t ->
-  delay:float ->
+  duration:float ->
   unit Undoable.t
 
 val focus_pure : ?margin:float -> Window.t -> Brr.El.t list -> unit Fut.t
 
 val focus :
-  ?delay:float -> ?margin:float -> Window.t -> Brr.El.t list -> unit Undoable.t
+  ?duration:float ->
+  ?margin:float ->
+  Window.t ->
+  Brr.El.t list ->
+  unit Undoable.t
 
-val enter : Window.t -> Brr.El.t -> unit Undoable.t
+val enter :
+  ?duration:float -> ?margin:float -> Window.t -> Brr.El.t -> unit Undoable.t
 
 val up :
-  ?delay:float -> ?margin:float -> Window.t -> Brr.El.t -> unit Undoable.t
+  ?duration:float -> ?margin:float -> Window.t -> Brr.El.t -> unit Undoable.t
 
 val center :
-  ?delay:float -> ?margin:float -> Window.t -> Brr.El.t -> unit Undoable.t
+  ?duration:float -> ?margin:float -> Window.t -> Brr.El.t -> unit Undoable.t
 
 val down :
-  ?delay:float -> ?margin:float -> Window.t -> Brr.El.t -> unit Undoable.t
+  ?duration:float -> ?margin:float -> Window.t -> Brr.El.t -> unit Undoable.t
 
 val scroll :
-  ?delay:float -> ?margin:float -> Window.t -> Brr.El.t -> unit Undoable.t
+  ?duration:float -> ?margin:float -> Window.t -> Brr.El.t -> unit Undoable.t

--- a/src/engine/universe/move.mli
+++ b/src/engine/universe/move.mli
@@ -17,7 +17,15 @@ val focus :
   ?delay:float -> ?margin:float -> Window.t -> Brr.El.t list -> unit Undoable.t
 
 val enter : Window.t -> Brr.El.t -> unit Undoable.t
-val up : Window.t -> Brr.El.t -> unit Undoable.t
-val center : Window.t -> Brr.El.t -> unit Undoable.t
-val down : Window.t -> Brr.El.t -> unit Undoable.t
-val scroll : Window.t -> Brr.El.t -> unit Undoable.t
+
+val up :
+  ?delay:float -> ?margin:float -> Window.t -> Brr.El.t -> unit Undoable.t
+
+val center :
+  ?delay:float -> ?margin:float -> Window.t -> Brr.El.t -> unit Undoable.t
+
+val down :
+  ?delay:float -> ?margin:float -> Window.t -> Brr.El.t -> unit Undoable.t
+
+val scroll :
+  ?delay:float -> ?margin:float -> Window.t -> Brr.El.t -> unit Undoable.t

--- a/src/engine/universe/move.mli
+++ b/src/engine/universe/move.mli
@@ -12,7 +12,10 @@ val move_relative :
   unit Undoable.t
 
 val focus_pure : ?margin:float -> Window.t -> Brr.El.t list -> unit Fut.t
-val focus : ?margin:float -> Window.t -> Brr.El.t list -> unit Undoable.t
+
+val focus :
+  ?delay:float -> ?margin:float -> Window.t -> Brr.El.t list -> unit Undoable.t
+
 val enter : Window.t -> Brr.El.t -> unit Undoable.t
 val up : Window.t -> Brr.El.t -> unit Undoable.t
 val center : Window.t -> Brr.El.t -> unit Undoable.t

--- a/src/engine/universe/window.ml
+++ b/src/engine/universe/window.ml
@@ -102,6 +102,7 @@ let live_scale { scale_container; _ } =
 
 let move_pure window ({ x; y; scale } as target : Coordinates.window) ~duration
     =
+  Brr.Console.(log [ "Moving with duration"; duration ]);
   let duration = if !fast_move then 0. else duration in
   let old_scale =
     let live_scale = live_scale window in

--- a/src/engine/universe/window.ml
+++ b/src/engine/universe/window.ml
@@ -100,8 +100,9 @@ let live_scale { scale_container; _ } =
   in
   compute_scale scale_container
 
-let move_pure window ({ x; y; scale } as target : Coordinates.window) ~delay =
-  let delay = if !fast_move then 0. else delay in
+let move_pure window ({ x; y; scale } as target : Coordinates.window) ~duration
+    =
+  let duration = if !fast_move then 0. else duration in
   let old_scale =
     let live_scale = live_scale window in
     let { Coordinates.scale = state_scale; _ } = State.get_coord () in
@@ -118,15 +119,15 @@ let move_pure window ({ x; y; scale } as target : Coordinates.window) ~delay =
     else if old_scale /. scale > 1.1 then `Unzoom
     else `Flat
   in
-  let (scale_function, scale_delay), (universe_function, universe_delay) =
+  let (scale_function, scale_duration), (universe_function, universe_duration) =
     let open Browser.Css in
     match transitions_style with
     | `Zoom ->
-        ( (TransitionTiming "ease-in", TransitionDelay (0.5 *. delay)),
+        ( (TransitionTiming "ease-in", TransitionDelay (0.5 *. duration)),
           (TransitionTiming "ease-out", TransitionDelay 0.) )
     | `Unzoom ->
         ( (TransitionTiming "ease-out", TransitionDelay 0.),
-          (TransitionTiming "ease-in", TransitionDelay (0.5 *. delay)) )
+          (TransitionTiming "ease-in", TransitionDelay (0.5 *. duration)) )
     | `Flat ->
         ( (TransitionTiming "", TransitionDelay 0.),
           (TransitionTiming "", TransitionDelay 0.) )
@@ -134,13 +135,15 @@ let move_pure window ({ x; y; scale } as target : Coordinates.window) ~delay =
   State.set_coord target;
   let x = -.x +. (width () /. 2.) in
   let y = -.y +. (height () /. 2.) in
-  let+ () = Browser.Css.set [ TransitionDuration delay ] window.scale_container
+  let+ () =
+    Browser.Css.set [ TransitionDuration duration ] window.scale_container
   and+ () = Browser.Css.set [ scale_function ] window.scale_container
-  and+ () = Browser.Css.set [ scale_delay ] window.scale_container
-  and+ () = Browser.Css.set [ TransitionDuration delay ] window.rotate_container
-  and+ () = Browser.Css.set [ TransitionDuration delay ] window.universe
+  and+ () = Browser.Css.set [ scale_duration ] window.scale_container
+  and+ () =
+    Browser.Css.set [ TransitionDuration duration ] window.rotate_container
+  and+ () = Browser.Css.set [ TransitionDuration duration ] window.universe
   and+ () = Browser.Css.set [ universe_function ] window.universe
-  and+ () = Browser.Css.set [ universe_delay ] window.universe
+  and+ () = Browser.Css.set [ universe_duration ] window.universe
   and+ () = Browser.Css.set [ Translate { x; y } ] window.universe
   and+ () = Browser.Css.set [ Scale scale ] window.scale_container in
   ()

--- a/src/engine/universe/window.mli
+++ b/src/engine/universe/window.mli
@@ -3,7 +3,7 @@ type t
 val pp : t -> unit
 val setup : Brr.El.t -> t Fut.t
 val translate_coords : float * float -> float * float
-val move_pure : t -> Coordinates.window -> delay:float -> unit Fut.t
+val move_pure : t -> Coordinates.window -> duration:float -> unit Fut.t
 
 val with_fast_moving : (unit -> unit Fut.t) -> unit Fut.t
 (** Inside this scope, window movement are immediate no matter the initial delay

--- a/src/static_data/data_files.ml
+++ b/src/static_data/data_files.ml
@@ -17,10 +17,10 @@ let string_of_file = function
   | _ -> assert false
 
 let read f =match f with
-  | Slipshow_js -> [%blob "src/engine/slipshow.js"]
-  | Slip_internal_css -> [%blob "src/engine/slipshow-internal.css"]
-  | Slip_system_css -> [%blob "src/engine/slipshow-system.css"]
-  | Favicon -> [%blob "logo/favicon.ico"]
+  | Slipshow_js -> [%blob "../engine/slipshow.js"]
+  | Slip_internal_css -> [%blob "../engine/slipshow-internal.css"]
+  | Slip_system_css -> [%blob "../engine/slipshow-system.css"]
+  | Favicon -> [%blob "../../logo/favicon.ico"]
   | _ ->
      Data_contents.read (string_of_file f)
      |> function

--- a/test/compiler/normal-slides.t/run.t
+++ b/test/compiler/normal-slides.t/run.t
@@ -2,22 +2,4 @@ We can compile the file using the slip_of_mark binary
 
   $ slipshow compile slides.md
 
-  $ cat slides.html | grep "<body>" -A 15
-    <body>
-      <div id="slipshow-main">
-        <div id="slipshow-content">
-          <svg id="slipshow-drawing-elem" style="overflow:visible; position: absolute; z-index:1000"></svg>
-          <div class="slipshow-rescaler" slipshow-entry-point>
-  <div class="slip">
-  <div class="slip-body">
-  <div style="display: flex">
-  <div id="slide1" class="slipshow-rescaler" slide enter-at-unpause>
-  <div class="slide">
-  <div class="slide-body">
-  <div>
-  <h1 id="first-title"><a class="anchor" aria-hidden="true" href="#first-title"></a><span>First title</span></h1>
-  <p><span>Aren’t you just bored with all those slides-based presentations?</span></p>
-  </div>
-  </div>
-
-  $ cp slides.html /tmp/slides2.html
+$ cp slides.html /tmp/slides2.html

--- a/test/compiler/normal-slides.t/run.t
+++ b/test/compiler/normal-slides.t/run.t
@@ -1,0 +1,23 @@
+We can compile the file using the slip_of_mark binary
+
+  $ slipshow compile slides.md
+
+  $ cat slides.html | grep "<body>" -A 15
+    <body>
+      <div id="slipshow-main">
+        <div id="slipshow-content">
+          <svg id="slipshow-drawing-elem" style="overflow:visible; position: absolute; z-index:1000"></svg>
+          <div class="slipshow-rescaler" slipshow-entry-point>
+  <div class="slip">
+  <div class="slip-body">
+  <div style="display: flex">
+  <div id="slide1" class="slipshow-rescaler" slide enter-at-unpause>
+  <div class="slide">
+  <div class="slide-body">
+  <div>
+  <h1 id="first-title"><a class="anchor" aria-hidden="true" href="#first-title"></a><span>First title</span></h1>
+  <p><span>Aren’t you just bored with all those slides-based presentations?</span></p>
+  </div>
+  </div>
+
+  $ cp slides.html /tmp/slides2.html

--- a/test/compiler/normal-slides.t/slides.md
+++ b/test/compiler/normal-slides.t/slides.md
@@ -1,0 +1,9 @@
+{children:slide children:enter="~duration:0"}
+----
+This is the first slide
+
+---
+
+# And now
+
+We are speaking!

--- a/test/compiler/slides.t/run.t
+++ b/test/compiler/slides.t/run.t
@@ -20,4 +20,4 @@ We can compile the file using the slip_of_mark binary
   </div>
   </div>
 
-  $ cp slides.html /tmp/
+$ cp slides.html /tmp/

--- a/test/engine/action-arguments.t/actions.md
+++ b/test/engine/action-arguments.t/actions.md
@@ -1,0 +1,3 @@
+This is a{#one} text with several words{#two}
+
+{focus="~delay:4 one ~margin:200. two"}

--- a/test/engine/action-arguments.t/run.t
+++ b/test/engine/action-arguments.t/run.t
@@ -1,0 +1,5 @@
+
+
+  $ slipshow compile actions.md
+$ cp actions.html /tmp/
+

--- a/test/engine/campus_du_libre.t/run.t
+++ b/test/engine/campus_du_libre.t/run.t
@@ -1,5 +1,5 @@
 
 
   $ slipshow compile cdl.md
-$ cp cdl.html /tmp/
+  $ cp cdl.html /tmp/
 

--- a/test/engine/campus_du_libre.t/run.t
+++ b/test/engine/campus_du_libre.t/run.t
@@ -1,5 +1,5 @@
 
 
   $ slipshow compile cdl.md
-  $ cp cdl.html /tmp/
+$ cp cdl.html /tmp/
 

--- a/vendor/github.com/panglesd/cmarkit/src/cmarkit.mli
+++ b/vendor/github.com/panglesd/cmarkit/src/cmarkit.mli
@@ -276,7 +276,7 @@ module Attributes : sig
   type key = string
   (** The type for attributes keys. *)
 
-  type value = string
+  type value = {v : string ; delimiter: char option}
   (** The type for attributes values. *)
 
   val empty : t

--- a/vendor/github.com/panglesd/cmarkit/src/cmarkit_base.mli
+++ b/vendor/github.com/panglesd/cmarkit/src/cmarkit_base.mli
@@ -306,7 +306,7 @@ type html_block_end_cond =
 type attributes = [
   | `Class of rev_spans
   | `Id of rev_spans
-  | `Kv_attr of  line_span * rev_spans option
+  | `Kv_attr of  line_span * (rev_spans * char option (* delimiter *)) option
 ]
 
 type line_type =
@@ -394,7 +394,7 @@ val md_attributes:
   ('a * line_span *
      [> `Class of (Textloc.byte_pos * line_span) list
      | `Id of (Textloc.byte_pos * line_span) list
-     | `Kv_attr of line_span * (Textloc.byte_pos * line_span) list option ]
+     | `Kv_attr of  line_span * (rev_spans * char option (* delimiter *)) option ]
        list * int)
     option
 

--- a/vendor/github.com/panglesd/cmarkit/src/cmarkit_commonmark.ml
+++ b/vendor/github.com/panglesd/cmarkit/src/cmarkit_commonmark.ml
@@ -209,7 +209,8 @@ let attributes ?(inline = false) c attrs =
           (function
            | `Id v -> "#"^v
            | `Class v -> "." ^ v
-           | `Kv (k, Some v) -> k^"="^v
+           | `Kv (k, Some {Attributes.v; delimiter = Some delim}) -> Format.sprintf "%s=%c%s%c" k delim v delim
+           | `Kv (k, Some {Attributes.v; delimiter = None}) -> k^"="^v
            | `Kv (k, None) -> k
           ) attrs
       in

--- a/vendor/github.com/panglesd/cmarkit/src/cmarkit_html.ml
+++ b/vendor/github.com/panglesd/cmarkit/src/cmarkit_html.ml
@@ -129,8 +129,12 @@ let pct_encoded_string c s = buffer_add_pct_encoded_string (C.buffer c) s
 
 (* Rendering functions *)
 
-let add_attr c (key, value) = match value with
-  | Some value -> C.string c (" " ^ key ^ "=" ^ value);
+let add_attr c (key, value) =
+  match value with
+  | Some {Attributes.v = value; delimiter = Some d} ->
+     let s = Format.sprintf " %s=%c%s%c" key d value d in
+     C.string c s
+  | Some {Attributes.v = value; delimiter = None} -> C.string c (" " ^ key ^ "=" ^ value);
   | None -> C.string c (" " ^ key)
 
 let add_attrs c attrs =
@@ -147,12 +151,14 @@ let add_attrs c attrs =
     let class' = List.map (fun (c, _) -> c) class' in
     match class' with
     | [] -> []
-    | _ -> ["class", Some ("\"" ^ String.concat " " class' ^ "\"") ]
+    | _ ->
+       let v = String.concat " " class' in
+       ["class", Some {Attributes.v ; delimiter = Some '"'} ]
   in
   let id =
     let id = Cmarkit.Attributes.id attrs in
     match id with
-    | Some (id, _) -> ["id", Some ("\""^id^"\"") ]
+    | Some (id, _) -> ["id", Some {Attributes.v =id; delimiter = Some '"'} ]
     | None -> []
   in
   let attrs = id @ class' @ kv_attrs in

--- a/vendor/github.com/panglesd/cmarkit/test/spec.ml
+++ b/vendor/github.com/panglesd/cmarkit/test/spec.ml
@@ -70,7 +70,7 @@ let cli ~exe () =
   let pos s = try examples := int_of_string s :: !examples with
   | Failure _ ->
       try
-        match String.cut_left ~sep:"-" s with
+        match String.cut ~sep:"-" s with
         | None -> failwith ""
         | Some (l, r) ->
             let l = int_of_string l in


### PR DESCRIPTION
Add (OCaml-inspired) syntax arguments to actions. For instance

```
{up="~duration:0 ~margin:10 id"}
```
Youpi!

Also, more minor changes:
- Fix `children:` attributes not being rewritten with `at-unpause`.
- Compatibility with next `Cmdliner` version
- Fix `"` sometimes being present in Cmarkit, removing the need for ~~hacks~~ workarounds.