### PR TITLE
Fix key stroke being taken into account when focused on an editable element.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add support for videos (#139)
 
+### Engine
+
+- Fix compatibility of slipshow and editable content (#141)
+
 ## [v0.4.1] (Wednesday 16th July, 2025)
 
 ### Engine

--- a/vendor/github.com/panglesd/brr/src/brr.ml
+++ b/vendor/github.com/panglesd/brr/src/brr.ml
@@ -1247,6 +1247,7 @@ module El = struct
 
   let is_txt e = Jv.Int.get e "nodeType" = 3
   let is_el e = Jv.Int.get e "nodeType" = 1
+  let is_content_editable e = Jv.Bool.get e "isContentEditable"
   let tag_name e = Jstr.lowercased @@ Jv.Jstr.get e "nodeName"
   let has_tag_name n e = Jstr.equal n (tag_name e)
   let txt_text txt = match is_txt txt with
@@ -1482,6 +1483,18 @@ module El = struct
 
   let click e = ignore (Jv.call e "click" [||])
   let select_text e = ignore (Jv.call e "select" [||])
+
+  (* Shadow root *)
+
+  module Shadow_root = struct
+    type t = Jv.t
+
+    let active_element v = Jv.get v "activeElement" |> Jv.to_option of_jv
+
+    include (Jv.Id : Jv.CONV with type t := t)
+  end
+
+  let shadow_root e = Jv.get e "shadowRoot" |> Jv.to_option Shadow_root.of_jv
 
   (* Fullscreen *)
 

--- a/vendor/github.com/panglesd/brr/src/brr.mli
+++ b/vendor/github.com/panglesd/brr/src/brr.mli
@@ -2092,6 +2092,11 @@ module El : sig
   val is_el : t -> bool
   (** [is_el e] is [true] iff [e] is an element node. *)
 
+  val is_content_editable : t -> bool
+  (** [is_content_editable e] is [true] iff the content of [e] is editable (see
+      {{:https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/isContentEditable}the
+      relevant doc}). *)
+
   val tag_name : t -> tag_name
   (** [name e] is the tag name of element [e] lowercased. For {!is_txt}
       nodes this returns ["#text"]. *)
@@ -2390,6 +2395,21 @@ module El : sig
       to [e] in the document it belongs to. This listens on the
       document for the next {!Ev.pointerlockchange} and
       {!Ev.pointerlockerror} to resolve the future appropriately. *)
+
+  (** {1:shadowroot Shadow root} *)
+
+  module Shadow_root : sig
+    type t
+
+    val active_element : t -> el option
+
+    (**/**)
+    include Jv.CONV with type t := t
+    (**/**)
+
+  end
+
+  val shadow_root : t -> Shadow_root.t option
 
   (** {1:fullscreen Fullscreen} *)
 


### PR DESCRIPTION
Logic to detect focused element and decide whether it is editable or not. If it's editable, do not consider key event.

This makes slipshow more compatible with [`x-ocaml`](https://github.com/art-w/x-ocaml), CC @patricoferris!