### PR TITLE
Fix sliphub focus

### DIFF
--- a/src/compiler/slipshow.ml
+++ b/src/compiler/slipshow.ml
@@ -214,7 +214,7 @@ let add_starting_state (start, end_) (starting_state : starting_state option) =
 %s
 </head>
   <body>
-          <iframe name="slipshow_main_pres" id="slipshow__internal_iframe" srcdoc="%s" style="
+          <iframe autofocus name="slipshow_main_pres" id="slipshow__internal_iframe" srcdoc="%s" style="
     width: 100%%;
     height: 100%%;
     position: fixed;
@@ -225,11 +225,6 @@ let add_starting_state (start, end_) (starting_state : starting_state option) =
     bottom: 0;
 "></iframe>
 
-<script>
-document.getElementById('slipshow__internal_iframe').addEventListener('load', function () {
-    this.contentWindow.focus();
-});
-</script>
       <script>
       %s
       </script>

--- a/src/engine/previewer/previewer.ml
+++ b/src/engine/previewer/previewer.ml
@@ -60,6 +60,15 @@ let create_previewer ?(initial_stage = 0) ?(callback = fun _ -> ()) root =
               send_speaker_view `Open panels.(1 - !index));
             index := 1 - !index;
             Brr.El.set_class (Jstr.v "active_panel") true panels.(!index);
+            let contentDocument el =
+              Jv.get (Brr.El.to_jv el) "contentDocument" |> Brr.Document.of_jv
+            in
+            let inner_iframe =
+              panels.(!index) |> contentDocument |> fun d ->
+              Brr.Document.find_el_by_id d (Jstr.v "slipshow__internal_iframe")
+              |> Option.get
+            in
+            let () = Brr.El.set_has_focus true inner_iframe in
             Brr.El.set_class (Jstr.v "active_panel") false panels.(1 - !index)
         | _ -> ())
       (Brr.Window.as_target Brr.G.window)


### PR DESCRIPTION
Fix sliphub focus (the focus was set too aggresively, meaning that on each keystroke, the focus of the editor was lost on the benefit of the preview) without breaking the focus of the hot-reload server.