### PR TITLE
Use the right x86_64 image for mac runner in GH action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -86,7 +86,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { os: "macos-14", arch: "x86_64" }
+          - { os: "macos-15-intel", arch: "x86_64" }
           - { os: "macos-14", arch: "arm64" }
         ocaml-compiler:
           - 4.14.x


### PR DESCRIPTION
Fix #195.