### PR TITLE
More convenient raw html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@
   - Go to definition (from IDs in action, to the associated element)
   - Occurrences of ID
   - Completion for IDs in actions
-- (#233) Add preview server capabilities to the LSP server
+- Add preview server capabilities to the LSP server (#233)
+- Add more syntax to include raw html, either in the file or as external file
+  (#236)
 
 ### Changed
 

--- a/docs/slipshow-syntax.rst
+++ b/docs/slipshow-syntax.rst
@@ -60,8 +60,8 @@ Links
 Links are included with the following syntax: ``[text](link target)``.
 
 
-Images, SVGs, videos, audios, PDFs, drawings
---------------------------------------------
+Images, SVGs, videos, audios, PDFs, HTML files, drawings
+--------------------------------------------------------
 
 Images and several other objects are included with the following syntax:
 ``![alternative text](path/to/file.extension)``.
@@ -78,6 +78,8 @@ Videos are recognized either from the ``video`` attribute, or an extension from:
 Audios are recognized either from the ``audio`` attribute, or an extension from: ``.aac``, ``.flac``, ``.mp3``, ``.oga``, ``.wav``.
 
 Pdfs are recognized from the ``.pdf`` extension.
+
+HTML files are recognized from the ``.html`` extension.
 
 Drawings are recognized from the ``.draw`` extension.
 

--- a/docs/special-elements.rst
+++ b/docs/special-elements.rst
@@ -7,7 +7,7 @@ can be used to define more elements, such as boxes, subslips, carousel, ...
 
 This page provides a reference for all such elements.
 
-.. contents:: Outline of the tutorial
+.. contents::
    :local:
 
 Boxes, admonitions and math environments
@@ -116,6 +116,14 @@ Includes are a way to include external markdown files, just as if they were inli
    {include slip src="part1.md"}
 
    {include slip src="part2.md"}
+
+It is also possible to include external Images, SVGs, videos, audios, PDFs, HTML
+files and drawings using the markdown image syntax:
+
+.. code-block::
+
+   This sentence includes ![](file.html) some raw html from an external file.
+
 
 .. _blockquote-in-special-elements:
 

--- a/docs/special-elements.rst
+++ b/docs/special-elements.rst
@@ -138,12 +138,23 @@ Since ``>`` is used for :ref:`using-less-to-group`, we can create them by assign
    >
    > Even with multiple paragraphs.
 
-HTML blocks
------------
+HTML spans and blocks
+---------------------
 
 While Markdown conveniently allows to inline some HTML, the rules for it are not
 obvious. If you want to be sure that some content is included as html, you can
-use use code block with the ``=html`` language value.
+use use code block and code spans, with the ``as-html`` attribute.
+
+.. code-block::
+
+   {as-html}
+   ```
+   <marquee>This is included as html, not as a code block</marquee>
+   ```
+
+   This text includes `<blink>some html</blink>`{as-html}.
+
+For consistency, it is alternatively possible to give a code block the ``=html`` language:
 
 .. code-block::
 

--- a/docs/special-elements.rst
+++ b/docs/special-elements.rst
@@ -137,3 +137,16 @@ Since ``>`` is used for :ref:`using-less-to-group`, we can create them by assign
    > This is NOT a blockquote.
    >
    > Even with multiple paragraphs.
+
+HTML blocks
+-----------
+
+While Markdown conveniently allows to inline some HTML, the rules for it are not
+obvious. If you want to be sure that some content is included as html, you can
+use use code block with the ``=html`` language value.
+
+.. code-block::
+
+   ```=html
+   <marquee>This is included as html, not as a code block</marquee>
+   ```

--- a/docs/special-elements.rst
+++ b/docs/special-elements.rst
@@ -104,10 +104,14 @@ A carousel is created simply by giving it a ``carousel`` attribute. Carousels ar
 
 Carousel will take the height of their current displayed element, unless the ``carousel-fixed-size`` class is added to the carousel. In which case, it takes the height of the tallest element.
 
-Includes
---------
+Includes for Markdown and HTML
+------------------------------
 
-Includes are a way to include external markdown files, just as if they were inlined in the file. An include must be a standalone attribute. It must have the ``include`` boolean attribute and ``src="path/to/file.md"`` key-value attribute. It is possible to add other attributes as well.
+Includes are a way to include external markdown/HTML files, just as if they were
+inlined in the file, similar to the ``![](...)`` syntax but for blocks. An
+include must be a standalone attribute. It must have the ``include`` boolean
+attribute and ``src="path/to/file.md"`` key-value attribute. It is possible to
+add other attributes as well.
 
 .. code-block::
 
@@ -117,8 +121,12 @@ Includes are a way to include external markdown files, just as if they were inli
 
    {include slip src="part2.md"}
 
-It is also possible to include external Images, SVGs, videos, audios, PDFs, HTML
-files and drawings using the markdown image syntax:
+   {include src="conclusion.html"}
+
+   {include src="drawing.svg"}
+
+Recall that for inline elements, it is possible images, SVGs, videos, audios,
+PDFs, HTML files and drawings using the markdown image syntax:
 
 .. code-block::
 

--- a/src/cli/main.ml
+++ b/src/cli/main.ml
@@ -88,6 +88,11 @@ module Compile = struct
     | `Stdout -> Error "Standard output cannot be used in serve nor watch mode"
 
   let compile ~watch ~compile_args:{ Compile_args.input; output } =
+    let () =
+      match Sys.getenv_opt "SLIPSHOW__SECRET__NO_ENGINE" with
+      | Some "TRUE" -> Slipshow.set_no_engine ()
+      | _ -> ()
+    in
     let output = Utils.output_of_input ~ext:"html" output input in
     if watch then
       let* input, output = force_file_io input output in

--- a/src/compiler/ast.ml
+++ b/src/compiler/ast.ml
@@ -6,6 +6,7 @@ type slide = { content : Block.t; title : Inline.t attributed option }
 
 type s_block =
   | Included of Fpath.t attributed node
+  | IncludedHTML of Fpath.t attributed node
   | Div of Block.t attributed node
   | Slide of slide attributed node
   | Slip of Block.t attributed node
@@ -16,6 +17,7 @@ type s_block =
 type Block.t += S_block of s_block
 
 let included d = S_block (Included d)
+let included_html d = S_block (IncludedHTML d)
 let div d = S_block (Div d)
 let slide d = S_block (Slide d)
 let slip d = S_block (Slip d)
@@ -155,7 +157,7 @@ module Folder = struct
     | Div ((b, _), _)
     | Slip ((b, _), _) ->
         Folder.fold_block f acc b
-    | Included _ | MermaidJS _ | SlipScript _ -> acc
+    | IncludedHTML _ | Included _ | MermaidJS _ | SlipScript _ -> acc
     | Carousel ((l, _), _) ->
         List.fold_left (fun acc x -> Folder.fold_block f acc x) acc l
 
@@ -252,7 +254,7 @@ module Folder = struct
         | Div ((b, _), _)
         | Slip ((b, _), _) ->
             Folder.fold_block f acc b
-        | Included _ | MermaidJS _ | SlipScript _ -> acc
+        | IncludedHTML _ | Included _ | MermaidJS _ | SlipScript _ -> acc
         | Carousel ((l, _), _) ->
             List.fold_left (fun acc x -> Folder.fold_block f acc x) acc l)
     | _ -> assert false
@@ -300,6 +302,9 @@ module Mapper = struct
     | Included ((fpath, attrs), meta) ->
         let attrs = (Mapper.map_attrs m (fst attrs), snd attrs) in
         Some (Included ((fpath, attrs), meta))
+    | IncludedHTML ((fpath, attrs), meta) ->
+        let attrs = (Mapper.map_attrs m (fst attrs), snd attrs) in
+        Some (IncludedHTML ((fpath, attrs), meta))
     | Slide (({ content = b; title }, attrs), meta) ->
         let* b = Mapper.map_block m b in
         let title =
@@ -397,6 +402,10 @@ module Fold_mapper = struct
           | Included ((fpath, attrs), meta) ->
               let acc, attrs = m.attrs acc $ attrs in
               let res = Included ((fpath, attrs), meta) in
+              (acc, Some res)
+          | IncludedHTML ((fpath, attrs), meta) ->
+              let acc, attrs = m.attrs acc $ attrs in
+              let res = IncludedHTML ((fpath, attrs), meta) in
               (acc, Some res)
           | Div ((block, attrs), meta) ->
               let acc, attrs = m.attrs acc $ attrs in
@@ -524,6 +533,8 @@ module Utils = struct
           match b with
           | Included ((inc, attrs), meta) ->
               Some (included ((inc, attr_upd attrs), meta), attrs)
+          | IncludedHTML ((inc, attrs), meta) ->
+              Some (included_html ((inc, attr_upd attrs), meta), attrs)
           | Div ((d, attrs), meta) ->
               Some (div ((d, attr_upd attrs), meta), attrs)
           | Slide ((s, attrs), meta) ->
@@ -560,6 +571,7 @@ module Utils = struct
         | S_block b -> (
             match b with
             | Included (_, meta) -> meta
+            | IncludedHTML (_, meta) -> meta
             | Div (_, meta) -> meta
             | Slide (_, meta) -> meta
             | Slip (_, meta) -> meta

--- a/src/compiler/ast.ml
+++ b/src/compiler/ast.ml
@@ -760,12 +760,15 @@ module Ast_printer = struct
           pp_inline
           (Inline.Attributes_span.content attr_span)
     (* Slipshow Inlines *)
-    | S_inline (Image _) -> fprintf ppf "S_inline(Image)"
-    | S_inline (Svg _) -> fprintf ppf "S_inline(Svg)"
-    | S_inline (Video _) -> fprintf ppf "S_inline(Video)"
-    | S_inline (Audio _) -> fprintf ppf "S_inline(Audio)"
-    | S_inline (Pdf _) -> fprintf ppf "S_inline(Pdf)"
-    | S_inline (Hand_drawn _) -> fprintf ppf "S_inline(Hand_drawn)"
+    | S_inline i -> (
+        match i with
+        | Image _ -> fprintf ppf "S_inline(Image)"
+        | Svg _ -> fprintf ppf "S_inline(Svg)"
+        | Video _ -> fprintf ppf "S_inline(Video)"
+        | Audio _ -> fprintf ppf "S_inline(Audio)"
+        | Pdf _ -> fprintf ppf "S_inline(Pdf)"
+        | Html _ -> fprintf ppf "S_inline(Html)"
+        | Hand_drawn _ -> fprintf ppf "S_inline(Hand_drawn)")
     (* Catch-all for open variants *)
     | _ -> fprintf ppf "Unknown_inline");
 
@@ -814,23 +817,26 @@ module Ast_printer = struct
     | Block.Ext_attribute_definition ((_def, attrs), _) ->
         fprintf ppf "Ext_attribute_definition%a" pp_attrs attrs
     (* Slipshow Blocks *)
-    | S_block (Included ((fpath, attrs), _)) ->
-        fprintf ppf "Included%a@ %a" pp_attrs attrs Fpath.pp fpath
-    | S_block (Div ((b, attrs), _)) ->
-        fprintf ppf "Div%a@ %a" pp_attrs attrs pp_block b
-    | S_block (Slide (({ content; title }, attrs), _)) ->
-        fprintf ppf "Slide%a@ Title: %a@ Content: %a" pp_attrs attrs
-          (pp_print_option (fun fmt (t, _) -> pp_inline fmt t))
-          title pp_block content
-    | S_block (Slip ((b, attrs), _)) ->
-        fprintf ppf "Slip%a@ %a" pp_attrs attrs pp_block b
-    | S_block (SlipScript ((_s, attrs), _)) ->
-        fprintf ppf "SlipScript%a" pp_attrs attrs
-    | S_block (MermaidJS ((_s, attrs), _)) ->
-        fprintf ppf "MermaidJS%a" pp_attrs attrs
-    | S_block (Carousel ((l, attrs), _)) ->
-        fprintf ppf "Carousel%a@ @[<v>%a@]" pp_attrs attrs
-          (pp_print_list pp_block) l
+    | S_block b -> (
+        match b with
+        | Included ((fpath, attrs), _) ->
+            fprintf ppf "Included%a@ %a" pp_attrs attrs Fpath.pp fpath
+        | IncludedHTML ((fpath, attrs), _) ->
+            fprintf ppf "IncludedHTML%a@ %a" pp_attrs attrs Fpath.pp fpath
+        | Div ((b, attrs), _) ->
+            fprintf ppf "Div%a@ %a" pp_attrs attrs pp_block b
+        | Slide (({ content; title }, attrs), _) ->
+            fprintf ppf "Slide%a@ Title: %a@ Content: %a" pp_attrs attrs
+              (pp_print_option (fun fmt (t, _) -> pp_inline fmt t))
+              title pp_block content
+        | Slip ((b, attrs), _) ->
+            fprintf ppf "Slip%a@ %a" pp_attrs attrs pp_block b
+        | SlipScript ((_s, attrs), _) ->
+            fprintf ppf "SlipScript%a" pp_attrs attrs
+        | MermaidJS ((_s, attrs), _) -> fprintf ppf "MermaidJS%a" pp_attrs attrs
+        | Carousel ((l, attrs), _) ->
+            fprintf ppf "Carousel%a@ @[<v>%a@]" pp_attrs attrs
+              (pp_print_list pp_block) l)
     (* Catch-all for open variants *)
     | _ -> fprintf ppf "Unknown_block");
 

--- a/src/compiler/ast.ml
+++ b/src/compiler/ast.ml
@@ -35,6 +35,7 @@ type s_inline =
   | Video of media
   | Audio of media
   | Pdf of media
+  | Html of media
   | Hand_drawn of media
 
 type Inline.t += S_inline of s_inline
@@ -45,6 +46,7 @@ let video i = S_inline (Video i)
 let audio i = S_inline (Audio i)
 let pdf i = S_inline (Pdf i)
 let hand_drawn i = S_inline (Hand_drawn i)
+let html i = S_inline (Html i)
 
 type t = Cmarkit.Doc.t
 
@@ -167,6 +169,7 @@ module Folder = struct
     | Video { origin = (l, _), _; uri = _; id = _ }
     | Hand_drawn { origin = (l, _), _; uri = _; id = _ }
     | Svg { origin = (l, _), _; uri = _; id = _ }
+    | Html { origin = (l, _), _; uri = _; id = _ }
     | Image { origin = (l, _), _; uri = _; id = _ } ->
         Folder.fold_inline f acc (Cmarkit.Inline.Link.text l)
 
@@ -278,7 +281,7 @@ module Folder = struct
         Folder.fold_inline f acc inline
     | S_inline ext -> (
         match ext with
-        | Hand_drawn m | Image m | Svg m | Video m | Audio m | Pdf m ->
+        | Html m | Hand_drawn m | Image m | Svg m | Video m | Audio m | Pdf m ->
             let (link, _), _ = m.origin in
             let inline = Link.text link in
             Folder.fold_inline f acc inline)
@@ -359,6 +362,9 @@ module Mapper = struct
     | Hand_drawn media ->
         let media = map_media m media in
         Some (Hand_drawn media)
+    | Html media ->
+        let media = map_media m media in
+        Some (Html media)
 
   let inline_ext_default m = function
     | S_inline i -> inline_ext_default m i |> Option.map (fun i -> S_inline i)
@@ -465,6 +471,9 @@ module Fold_mapper = struct
           | Hand_drawn media ->
               let acc, media = map_media m acc media in
               (acc, Hand_drawn media)
+          | Html media ->
+              let acc, media = map_media m acc media in
+              (acc, Html media)
         in
         (acc, Some (S_inline i))
     | normal -> Fold_mapper.default.inline m acc normal
@@ -626,6 +635,10 @@ module Utils = struct
               let (link, attrs), meta = m.origin in
               let origin = ((link, attr_upd attrs), meta) in
               Some (S_inline (Audio { m with origin }), attrs)
+          | Html m ->
+              let (link, attrs), meta = m.origin in
+              let origin = ((link, attr_upd attrs), meta) in
+              Some (S_inline (Html { m with origin }), attrs)
           | Pdf m ->
               let (link, attrs), meta = m.origin in
               let origin = ((link, attr_upd attrs), meta) in
@@ -658,6 +671,7 @@ module Utils = struct
             | Video { origin = _, meta; _ } -> meta
             | Audio { origin = _, meta; _ } -> meta
             | Pdf { origin = _, meta; _ } -> meta
+            | Html { origin = _, meta; _ } -> meta
             | Hand_drawn { origin = _, meta; _ } -> meta)
         | _ -> assert false
       in

--- a/src/compiler/compile.ml
+++ b/src/compiler/compile.ml
@@ -59,6 +59,7 @@ let classify_image p =
       `Image
   | ".svg" -> `Svg
   | ".draw" -> `Draw
+  | ".html" -> `Html
   | _ -> `Image
 
 let resolve_file parent s =
@@ -129,6 +130,7 @@ module Stage1 = struct
     else if has_attrs Special_attrs.audio then `Audio
     else if has_attrs Special_attrs.image then `Image
     else if has_attrs Special_attrs.svg then `Svg
+    else if has_attrs Special_attrs.as_html then `Html
     (* else if has_attrs "pdf" then `Pdf *)
     (* else if has_attrs "draw" then `Draw
        We don't want to pollute too much the namespace.  *)
@@ -174,6 +176,7 @@ module Stage1 = struct
       | `Audio -> Ast.audio { uri; origin; id = Id.gen () }
       | `Draw -> Ast.hand_drawn { uri; origin; id = Id.gen () }
       | `Pdf -> Ast.pdf { uri; origin; id = Id.gen () }
+      | `Html -> Ast.html { uri; origin; id = Id.gen () }
     in
     Mapper.ret res
 
@@ -504,6 +507,7 @@ module Stage4 = struct
             | Audio media
             | Hand_drawn media
             | Svg media
+            | Html media
             | Image media -> (
                 match media with
                 | { uri = Path p, meta; id; origin = _ } ->
@@ -767,6 +771,7 @@ let to_cmarkit units =
     | Pdf { origin; _ }
     | Hand_drawn { origin; _ }
     | Svg { origin; _ }
+    | Html { origin; _ }
     | Image { origin; _ } ->
         `Map (Mapper.map_inline m (Inline.Image origin))
   in

--- a/src/compiler/compile.ml
+++ b/src/compiler/compile.ml
@@ -73,21 +73,31 @@ module Stage1 = struct
       match Mapper.map_block m b with None -> Block.empty | Some b -> b
     in
     let attrs = Mapper.map_attrs m attrs in
-    Some (Ast.div ((b, (attrs, meta2)), meta))
+    Ast.div ((b, (attrs, meta2)), meta)
 
-  let handle_slip_scripts_creation m ((cb, (attrs, meta)), meta2) =
+  let handle_code_blocks m ((cb, (attrs, meta)), meta2) =
     let attrs = Mapper.map_attrs m attrs in
     let attrs = (attrs, meta) in
     match Block.Code_block.info_string cb with
-    | None -> Some (Block.Code_block ((cb, attrs), meta2))
+    | None -> Block.Code_block ((cb, attrs), meta2)
     | Some (info, _) -> (
         match Block.Code_block.language_of_info_string info with
-        | Some ("slip-script", _) -> Some (Ast.slipscript ((cb, attrs), meta2))
-        | Some ("=mermaid", _) -> Some (Ast.mermaid_js ((cb, attrs), meta2))
+        | Some ("slip-script", _) -> Ast.slipscript ((cb, attrs), meta2)
+        | Some ("=mermaid", _) -> Ast.mermaid_js ((cb, attrs), meta2)
         | Some ("=html", _) ->
             let h = Block.Code_block.code cb in
-            Some (Block.Html_block ((h, attrs), meta2))
-        | _ -> Some (Block.Code_block ((cb, attrs), meta2)))
+            Block.Html_block ((h, attrs), meta2)
+        | _ -> Block.Code_block ((cb, attrs), meta2))
+
+  let handle_code_span m ((cs, (attrs, meta)), meta2) =
+    let attrs = Mapper.map_attrs m attrs in
+    let has_attrs x = Cmarkit.Attributes.find x attrs |> Option.is_some in
+    if has_attrs Special_attrs.as_html then
+      let code = Inline.Code_span.code_layout cs in
+      let html = Inline.Raw_html (code, meta2) in
+      let span = Inline.Attributes_span.make html (attrs, meta) in
+      Inline.Ext_attrs (span, meta2)
+    else Inline.Code_span ((cs, (attrs, meta)), meta2)
 
   let handle_includes m ~htbl_include current_path (attrs, meta) =
     match
@@ -285,15 +295,16 @@ module Stage1 = struct
     let ret x = `Map x in
     let block m = function
       | Block.Blocks bs -> ret @@ handle_dash_separated_blocks m bs
-      | Block.Block_quote bq -> ret @@ turn_block_quotes_into_divs m bq
-      | Block.Code_block cb -> ret @@ handle_slip_scripts_creation m cb
+      | Block.Block_quote bq -> ret @@ Some (turn_block_quotes_into_divs m bq)
+      | Block.Code_block cb -> ret @@ Some (handle_code_blocks m cb)
       | Block.Ext_standalone_attributes sa ->
           handle_includes m ~htbl_include current_path sa
       | _ -> Mapper.default
     in
     let attrs = map_attrs in
-    let inline i = function
-      | Inline.Image img -> handle_image_inlining i defs current_path img
+    let inline m = function
+      | Inline.Image img -> handle_image_inlining m defs current_path img
+      | Inline.Code_span cs -> Mapper.ret (handle_code_span m cs)
       | _ -> Mapper.default
     in
     Ast.Mapper.make ~block ~inline ~attrs ()

--- a/src/compiler/compile.ml
+++ b/src/compiler/compile.ml
@@ -100,23 +100,34 @@ module Stage1 = struct
       Inline.Ext_attrs (span, meta2)
     else Inline.Code_span ((cs, (attrs, meta)), meta2)
 
+  let handle_md_includes m ~htbl_include current_path (attrs, meta)
+      filepath_meta src =
+    let relativized_path = Fpath.normalize @@ Fpath.( // ) current_path src in
+    let old_value =
+      Hashtbl.find_opt htbl_include relativized_path |> Option.value ~default:[]
+    in
+    let new_value = Meta.textloc filepath_meta :: old_value in
+    Hashtbl.replace htbl_include relativized_path new_value;
+    let attrs = Mapper.map_attrs m attrs in
+    `Map (Some (Ast.included ((relativized_path, (attrs, meta)), meta)))
+
   let handle_includes m ~htbl_include current_path (attrs, meta) =
     match
       ( Attributes.find Special_attrs.include_ attrs,
         Attributes.find Special_attrs.src attrs )
     with
     | Some (_, None), Some (_, Some ({ v = src; _ }, filepath_meta)) ->
-        let relativized_path =
-          Fpath.normalize @@ Fpath.( // ) current_path (Fpath.v src)
-        in
-        let old_value =
-          Hashtbl.find_opt htbl_include relativized_path
-          |> Option.value ~default:[]
-        in
-        let new_value = Meta.textloc filepath_meta :: old_value in
-        Hashtbl.replace htbl_include relativized_path new_value;
-        let attrs = Mapper.map_attrs m attrs in
-        `Map (Some (Ast.included ((relativized_path, (attrs, meta)), meta)))
+        let src = Fpath.v src in
+        if Fpath.has_ext ".html" src || Fpath.has_ext ".svg" src then
+          let relativized_path =
+            Fpath.normalize @@ Fpath.( // ) current_path src
+          in
+          let attrs = Mapper.map_attrs m attrs in
+          `Map
+            (Some (Ast.included_html ((relativized_path, (attrs, meta)), meta)))
+        else
+          handle_md_includes m ~htbl_include current_path (attrs, meta)
+            filepath_meta src
     | _ -> `Default
 
   let get_link_definition (defs : Cmarkit.Label.defs) l =
@@ -477,14 +488,21 @@ module Stage4 = struct
     Fpath.Map.update path add fpath_map
 
   let execute =
-    let block f (x, id_list) c =
+    let block f (files, id_list) c =
+      let files =
+        match c with
+        | Ast.S_block (IncludedHTML ((p, _), meta)) ->
+            fpath_map_add_to_list p (Id.gen (), Meta.textloc meta) files
+        | _ -> files
+      in
       let acc =
         match Ast.Utils.Block.get_attribute c with
-        | None -> (x, id_list)
+        | None -> (files, id_list)
         | Some (_, (attrs, meta)) -> (
             match Attributes.id attrs with
-            | None -> (x, id_list)
-            | Some id -> (x, { Id_map.id; elem = `Block c; meta } :: id_list))
+            | None -> (files, id_list)
+            | Some id -> (files, { Id_map.id; elem = `Block c; meta } :: id_list)
+            )
       in
       let res = Ast.Folder.continue_block f c acc in
       Folder.ret res
@@ -541,44 +559,8 @@ module Stage4 = struct
             acc)
         Id_map.SMap.empty id_list
     in
-    (* let id_map = *)
-    (*   Id_map.SMap.filter_map *)
-    (*     (fun id list -> *)
-    (*       match list with *)
-    (*       | [] -> assert false *)
-    (*       | [ x ] -> Some x *)
-    (*       | x :: _ :: _ -> *)
-    (*           let occurrences = *)
-    (*             List.map *)
-    (*               (fun { Id_map.id = _id, meta1; elem = _; meta = _; rev = _ } *)
-    (*                  -> Meta.textloc meta1) *)
-    (*               list *)
-    (*           in *)
-    (*           Diagnosis.add @@ DuplicateID { id; occurrences }; *)
-    (*           Some x) *)
-    (*     id_map *)
-    (* in *)
-    let files =
-      (* Fpath.Map.filter_map *)
-      (*   (fun path used_by -> *)
-      (*     let read_file : file_reader = read_file in *)
-      (*     let mode = `Base64 in *)
-      (*     match read_file path with *)
-      (*     | Ok (Some (content, _)) -> *)
-      (*         let used_by = List.map fst used_by in *)
-      (*         Some { Ast.Files.content; mode; used_by; path } *)
-      (*     | Ok None -> None *)
-      (*     | Error (`Msg error_msg) -> *)
-      (*         let locs = *)
-      (*           List.map (fun (_id, (_node, meta)) -> Meta.textloc meta) used_by *)
-      (*         in *)
-      (*         Diagnosis.add *)
-      (*           (MissingFile { file = Fpath.to_string path; error_msg; locs }); *)
-      (*         None) *)
-      asset_map
-    in
+    let files = asset_map in
     (md, files, id_map)
-  (* ({ Ast.doc = md; files; options = fm.global }, id_map) *)
 end
 
 let action_plan _ = failwith "TODO: Action plan"
@@ -754,6 +736,7 @@ let to_cmarkit units =
               Mapper.map_block m b
         in
         `Map b
+    | IncludedHTML ((_, _), _meta) -> `Map None
     | Div ((bq, _), meta) | Slip ((bq, _), meta) ->
         let b =
           match Mapper.map_block m bq with None -> Block.empty | Some b -> b

--- a/src/compiler/compile.ml
+++ b/src/compiler/compile.ml
@@ -76,24 +76,29 @@ module Stage1 = struct
     let attrs = Mapper.map_attrs m attrs in
     Ast.div ((b, (attrs, meta2)), meta)
 
+  let has_attrs attrs x = Cmarkit.Attributes.find x attrs |> Option.is_some
+
   let handle_code_blocks m ((cb, (attrs, meta)), meta2) =
     let attrs = Mapper.map_attrs m attrs in
     let attrs = (attrs, meta) in
-    match Block.Code_block.info_string cb with
-    | None -> Block.Code_block ((cb, attrs), meta2)
-    | Some (info, _) -> (
-        match Block.Code_block.language_of_info_string info with
-        | Some ("slip-script", _) -> Ast.slipscript ((cb, attrs), meta2)
-        | Some ("=mermaid", _) -> Ast.mermaid_js ((cb, attrs), meta2)
-        | Some ("=html", _) ->
-            let h = Block.Code_block.code cb in
-            Block.Html_block ((h, attrs), meta2)
-        | _ -> Block.Code_block ((cb, attrs), meta2))
+    let html () =
+      let h = Block.Code_block.code cb in
+      Block.Html_block ((h, attrs), meta2)
+    in
+    if has_attrs (fst attrs) Special_attrs.as_html then html ()
+    else
+      match Block.Code_block.info_string cb with
+      | None -> Block.Code_block ((cb, attrs), meta2)
+      | Some (info, _) -> (
+          match Block.Code_block.language_of_info_string info with
+          | Some ("slip-script", _) -> Ast.slipscript ((cb, attrs), meta2)
+          | Some ("=mermaid", _) -> Ast.mermaid_js ((cb, attrs), meta2)
+          | Some ("=html", _) -> html ()
+          | _ -> Block.Code_block ((cb, attrs), meta2))
 
   let handle_code_span m ((cs, (attrs, meta)), meta2) =
     let attrs = Mapper.map_attrs m attrs in
-    let has_attrs x = Cmarkit.Attributes.find x attrs |> Option.is_some in
-    if has_attrs Special_attrs.as_html then
+    if has_attrs attrs Special_attrs.as_html then
       let code = Inline.Code_span.code_layout cs in
       let html = Inline.Raw_html (code, meta2) in
       let span = Inline.Attributes_span.make html (attrs, meta) in

--- a/src/compiler/compile.ml
+++ b/src/compiler/compile.ml
@@ -84,6 +84,9 @@ module Stage1 = struct
         match Block.Code_block.language_of_info_string info with
         | Some ("slip-script", _) -> Some (Ast.slipscript ((cb, attrs), meta2))
         | Some ("=mermaid", _) -> Some (Ast.mermaid_js ((cb, attrs), meta2))
+        | Some ("=html", _) ->
+            let h = Block.Code_block.code cb in
+            Some (Block.Html_block ((h, attrs), meta2))
         | _ -> Some (Block.Code_block ((cb, attrs), meta2)))
 
   let handle_includes m ~htbl_include current_path (attrs, meta) =

--- a/src/compiler/renderers.ml
+++ b/src/compiler/renderers.ml
@@ -159,6 +159,13 @@ let pdf c ~uri ~files i attrs =
       C.string c ">";
       C.string c "</span>"
 
+let html_include c ~uri ~files attrs i =
+  let open Cmarkit in
+  RenderAttrs.with_attrs_span c attrs @@ fun () ->
+  match src uri files with
+  | `Link _ -> C.inline c (Inline.Link.text i)
+  | `Source (content, _mimetype) -> C.string c content
+
 (* Inspired from Cmarkit's image rendering *)
 let media ?(close = " >") ~media_name c ~uri ~files i attrs =
   let open Cmarkit in
@@ -227,6 +234,9 @@ let custom_html_renderer (units : Ast.units)
           true
       | Ast.Audio { uri = uri, _; id = _; origin = (l, (attrs, _)), _ } ->
           media ~media_name:"audio" c ~uri ~files l attrs;
+          true
+      | Ast.Html { uri = uri, _; id = _; origin = (l, (attrs, _)), _ } ->
+          html_include c ~uri ~files attrs l;
           true
       | Ast.Hand_drawn { uri = uri, _; id = _; origin = (_, (attrs, _)), _ } ->
           let attrs =

--- a/src/compiler/renderers.ml
+++ b/src/compiler/renderers.ml
@@ -62,6 +62,10 @@ module RenderAttrs = struct
     if Attributes.is_empty attrs then f ()
     else in_block c ~with_newline "span" attrs f
 
+  let with_attrs_div c ?(with_newline = true) attrs f =
+    if Attributes.is_empty attrs then f ()
+    else in_block c ~with_newline "div" attrs f
+
   let () = ignore with_attrs_span
 
   let block_lines c = function
@@ -97,13 +101,14 @@ let to_string = function
   (* Slipshow nodes *)
   | Ast.S_block b -> (
       match b with
-      | Ast.Included _ -> "Included"
-      | Ast.Div _ -> "Div"
-      | Ast.Slide _ -> "Slide"
-      | Ast.Slip _ -> "Slip"
-      | Ast.SlipScript _ -> "Slipscript"
-      | Ast.MermaidJS _ -> "MermaidJS"
-      | Ast.Carousel _ -> "Carousel")
+      | Included _ -> "Included"
+      | IncludedHTML _ -> "Included"
+      | Div _ -> "Div"
+      | Slide _ -> "Slide"
+      | Slip _ -> "Slip"
+      | SlipScript _ -> "Slipscript"
+      | MermaidJS _ -> "MermaidJS"
+      | Carousel _ -> "Carousel")
   | _ -> "other"
 
 let () = ignore to_string
@@ -289,6 +294,16 @@ let custom_html_renderer (units : Ast.units)
             | Some unit ->
                 let b = Doc.block unit.Ast.ast in
                 div c b attrs
+          in
+          true
+      | Ast.IncludedHTML ((p, (attrs, _)), _) ->
+          let () =
+            RenderAttrs.with_attrs_div c attrs @@ fun () ->
+            match
+              Fpath.Map.find_opt p (files : Ast.Files.read Ast.Files.map)
+            with
+            | Some { content = Ok (Some html); _ } -> C.string c html
+            | _ -> ()
           in
           true
       | Ast.Div ((b, (attrs, _)), _) ->

--- a/src/compiler/slipshow.ml
+++ b/src/compiler/slipshow.ml
@@ -155,6 +155,9 @@ let head ~width ~height ~theme ~highlightjs_theme ~(has : Has.t) ~math_mode
       mermaid_option;
     ]
 
+let no_engine = ref false
+let set_no_engine () = no_engine := true
+
 let embed_in_page ~has_speaker_view ~slipshow_js content ~has ~math_link
     ~css_links ~js_links ~theme ~dimension ~highlightjs_theme ~math_mode =
   let width, height = dimension in
@@ -206,7 +209,7 @@ let embed_in_page ~has_speaker_view ~slipshow_js content ~has ~math_link
     </div>
     <!-- Include the library -->
       |};
-        slipshow_js_element;
+        (if !no_engine then "" else slipshow_js_element);
         {|
     <!-- Start the presentation () -->
     <script>hljs.highlightAll();</script>|};
@@ -361,7 +364,7 @@ let add_starting_state ?(autofocus = true) (start, end_, has_speaker_view)
 
       <script>
 |};
-        Data_files.(read Scheduler_js);
+        (if not !no_engine then Data_files.(read Scheduler_js) else "");
         {|
       </script>
   </body>

--- a/src/compiler/slipshow.mli
+++ b/src/compiler/slipshow.mli
@@ -64,3 +64,6 @@ val convert_to_md : read_file:file_reader -> Fpath.t -> string
 
 val to_grace :
   Ast.units -> Diagnosis.t list -> Diagnosis.t Grace.Diagnostic.t list
+
+val set_no_engine : unit -> unit
+(** Internal only *)

--- a/src/compiler/special_attrs.ml
+++ b/src/compiler/special_attrs.ml
@@ -11,6 +11,7 @@ let image = "image"
 let svg = "svg"
 let pdf_resolution = "pdf-resolution"
 let pause_block = "pause-block"
+let as_html = "as-html"
 
 let all_attrs =
   [
@@ -27,4 +28,5 @@ let all_attrs =
     svg;
     pdf_resolution;
     pause_block;
+    as_html
   ]

--- a/src/lspishow/current_ast.ml
+++ b/src/lspishow/current_ast.ml
@@ -174,7 +174,8 @@ let rec enter_block acc pos (block : Cmarkit.Block.t) =
       if pos_in_inline ~pos inline then enter_inline acc pos inline else acc
   | Slipshow.Ast.S_block b -> (
       match b with
-      | Included _ -> acc (* TODO: do *)
+      | Included _ -> acc
+      | IncludedHTML _ -> acc
       | Slip ((block, _), _) | Div ((block, _), _) ->
           if pos_in_block block ~pos then enter_block acc pos block else acc
       | Slide ((slide, _), _) ->

--- a/src/lspishow/current_ast.ml
+++ b/src/lspishow/current_ast.ml
@@ -124,7 +124,7 @@ let rec enter_inline acc pos (inline : Cmarkit.Inline.t) =
   (* Slipshow nodes *)
   | Slipshow.Ast.S_inline i -> (
       match i with
-      | Hand_drawn m | Image m | Svg m | Video m | Audio m | Pdf m ->
+      | Hand_drawn m | Html m | Image m | Svg m | Video m | Audio m | Pdf m ->
           let (link, _), _ = m.origin in
           let i = Link.text link in
           may_enter i)

--- a/src/lspishow/debug.ml
+++ b/src/lspishow/debug.ml
@@ -60,12 +60,15 @@ module Ast_printer = struct
           pp_inline
           (Inline.Attributes_span.content attr_span)
     (* Slipshow Inlines *)
-    | S_inline (Image _) -> fprintf ppf "S_inline(Image)"
-    | S_inline (Svg _) -> fprintf ppf "S_inline(Svg)"
-    | S_inline (Video _) -> fprintf ppf "S_inline(Video)"
-    | S_inline (Audio _) -> fprintf ppf "S_inline(Audio)"
-    | S_inline (Pdf _) -> fprintf ppf "S_inline(Pdf)"
-    | S_inline (Hand_drawn _) -> fprintf ppf "S_inline(Hand_drawn)"
+    | S_inline i -> (
+        match i with
+        | Image _ -> fprintf ppf "S_inline(Image)"
+        | Svg _ -> fprintf ppf "S_inline(Svg)"
+        | Video _ -> fprintf ppf "S_inline(Video)"
+        | Audio _ -> fprintf ppf "S_inline(Audio)"
+        | Pdf _ -> fprintf ppf "S_inline(Pdf)"
+        | Html _ -> fprintf ppf "S_inline(Html)"
+        | Hand_drawn _ -> fprintf ppf "S_inline(Hand_drawn)")
     (* Catch-all for open variants *)
     | _ -> fprintf ppf "Unknown_inline");
 
@@ -114,23 +117,26 @@ module Ast_printer = struct
     | Block.Ext_attribute_definition ((_def, attrs), _) ->
         fprintf ppf "Ext_attribute_definition%a" pp_attrs attrs
     (* Slipshow Blocks *)
-    | S_block (Included ((fpath, attrs), _)) ->
-        fprintf ppf "Included%a@ %a" pp_attrs attrs Fpath.pp fpath
-    | S_block (Div ((b, attrs), _)) ->
-        fprintf ppf "Div%a@ %a" pp_attrs attrs pp_block b
-    | S_block (Slide (({ content; title }, attrs), _)) ->
-        fprintf ppf "Slide%a@ Title: %a@ Content: %a" pp_attrs attrs
-          (pp_print_option (fun fmt (t, _) -> pp_inline fmt t))
-          title pp_block content
-    | S_block (Slip ((b, attrs), _)) ->
-        fprintf ppf "Slip%a@ %a" pp_attrs attrs pp_block b
-    | S_block (SlipScript ((_s, attrs), _)) ->
-        fprintf ppf "SlipScript%a" pp_attrs attrs
-    | S_block (MermaidJS ((_s, attrs), _)) ->
-        fprintf ppf "MermaidJS%a" pp_attrs attrs
-    | S_block (Carousel ((l, attrs), _)) ->
-        fprintf ppf "Carousel%a@ @[<v>%a@]" pp_attrs attrs
-          (pp_print_list pp_block) l
+    | S_block b -> (
+        match b with
+        | Included ((fpath, attrs), _) ->
+            fprintf ppf "Included%a@ %a" pp_attrs attrs Fpath.pp fpath
+        | IncludedHTML ((fpath, attrs), _) ->
+            fprintf ppf "IncludedHTML%a@ %a" pp_attrs attrs Fpath.pp fpath
+        | Div ((b, attrs), _) ->
+            fprintf ppf "Div%a@ %a" pp_attrs attrs pp_block b
+        | Slide (({ content; title }, attrs), _) ->
+            fprintf ppf "Slide%a@ Title: %a@ Content: %a" pp_attrs attrs
+              (pp_print_option (fun fmt (t, _) -> pp_inline fmt t))
+              title pp_block content
+        | Slip ((b, attrs), _) ->
+            fprintf ppf "Slip%a@ %a" pp_attrs attrs pp_block b
+        | SlipScript ((_s, attrs), _) ->
+            fprintf ppf "SlipScript%a" pp_attrs attrs
+        | MermaidJS ((_s, attrs), _) -> fprintf ppf "MermaidJS%a" pp_attrs attrs
+        | Carousel ((l, attrs), _) ->
+            fprintf ppf "Carousel%a@ @[<v>%a@]" pp_attrs attrs
+              (pp_print_list pp_block) l)
     (* Catch-all for open variants *)
     | _ -> fprintf ppf "Unknown_block");
 

--- a/src/server/server.ml
+++ b/src/server/server.ml
@@ -90,7 +90,7 @@ let preview (roots, get_roots) req =
   let root = roots file in
   match root with
   | None -> home_page (roots, get_roots) req
-  | Some root ->
+  | Some _root ->
       Format.eprintf "TARGET is %a\n%!" Fpath.pp file;
       Dream.log "A browser reloaded";
       Dream.html (html_source file)

--- a/test/compiler/dash-separator/children-slides.t/run.t
+++ b/test/compiler/dash-separator/children-slides.t/run.t
@@ -1,3 +1,4 @@
+  $ export SLIPSHOW__SECRET__NO_ENGINE=TRUE
   $ slipshow compile slides.md
   warning: Non standard attribute: 'key'
       ┌─ slides.md:24:2

--- a/test/compiler/dash-separator/dash-separator.t/run.t
+++ b/test/compiler/dash-separator/dash-separator.t/run.t
@@ -1,3 +1,4 @@
+  $ export SLIPSHOW__SECRET__NO_ENGINE=TRUE
   $ slipshow compile dash-sep.md
 
 Asterisks are still interpreted as horizontal lines

--- a/test/compiler/drawings.t/run.t
+++ b/test/compiler/drawings.t/run.t
@@ -1,3 +1,4 @@
+  $ export SLIPSHOW__SECRET__NO_ENGINE=TRUE
   $ slipshow compile drawings.md
 
   $ show_source drawings.html | grep x-data= -A 2 | cut -c 1-250

--- a/test/compiler/html_blocks.t/html_blocks.md
+++ b/test/compiler/html_blocks.t/html_blocks.md
@@ -6,6 +6,11 @@ not html
 <b id="grep_block">is html</b>
 ```
 
+{as-html}
+```
+<b class="grep_block">is html</b>
+```
+
 Some `code span`.
 
 And `<blink>grep_span</blink>`{as-html}.

--- a/test/compiler/html_blocks.t/html_blocks.md
+++ b/test/compiler/html_blocks.t/html_blocks.md
@@ -1,0 +1,7 @@
+```html
+not html
+```
+
+```=html
+<b id="grep_here">is html</b>
+```

--- a/test/compiler/html_blocks.t/html_blocks.md
+++ b/test/compiler/html_blocks.t/html_blocks.md
@@ -9,3 +9,5 @@ not html
 Some `code span`.
 
 And `<blink>grep_span</blink>`{as-html}.
+
+I can include external ![](inline.html).

--- a/test/compiler/html_blocks.t/html_blocks.md
+++ b/test/compiler/html_blocks.t/html_blocks.md
@@ -3,5 +3,9 @@ not html
 ```
 
 ```=html
-<b id="grep_here">is html</b>
+<b id="grep_block">is html</b>
 ```
+
+Some `code span`.
+
+And `<blink>grep_span</blink>`{as-html}.

--- a/test/compiler/html_blocks.t/html_blocks.md
+++ b/test/compiler/html_blocks.t/html_blocks.md
@@ -11,3 +11,5 @@ Some `code span`.
 And `<blink>grep_span</blink>`{as-html}.
 
 I can include external ![](inline.html).
+
+{include src=block.html}

--- a/test/compiler/html_blocks.t/run.t
+++ b/test/compiler/html_blocks.t/run.t
@@ -7,4 +7,7 @@
   $ show_source html_blocks.html | grep grep_span
   <p><span>And </span><span as-html><blink>grep_span</blink></span><span>.</span></p>
 
+  $ show_source html_blocks.html | grep "external_inline_grep"
+  <p><span>And </span><span as-html><blink>grep_span</blink></span><span>.</span></p>
+
 $ cp carousel.html /tmp/

--- a/test/compiler/html_blocks.t/run.t
+++ b/test/compiler/html_blocks.t/run.t
@@ -1,6 +1,10 @@
+  $ export SLIPSHOW__SECRET__NO_ENGINE=TRUE
   $ slipshow compile html_blocks.md
 
-  $ show_source html_blocks.html | grep grep_here
-  <b id="grep_here">is html</b>
+  $ show_source html_blocks.html | grep grep_block
+  <b id="grep_block">is html</b>
+
+  $ show_source html_blocks.html | grep grep_span
+  <p><span>And </span><span as-html><blink>grep_span</blink></span><span>.</span></p>
 
 $ cp carousel.html /tmp/

--- a/test/compiler/html_blocks.t/run.t
+++ b/test/compiler/html_blocks.t/run.t
@@ -1,0 +1,6 @@
+  $ slipshow compile html_blocks.md
+
+  $ show_source html_blocks.html | grep grep_here
+  <b id="grep_here">is html</b>
+
+$ cp carousel.html /tmp/

--- a/test/compiler/html_blocks.t/run.t
+++ b/test/compiler/html_blocks.t/run.t
@@ -8,6 +8,29 @@
   <p><span>And </span><span as-html><blink>grep_span</blink></span><span>.</span></p>
 
   $ show_source html_blocks.html | grep "external_inline_grep"
+  <p><span>I can include external </span><span id="external_inline_grep">Yo!</span><span>.</span></p>
+
+  $ show_source html_blocks.html | grep -C 10 "external_block"
+  <div class="slip">
+  <div class="slip-body">
+  <div src=html_blocks.md include>
+  <pre><code class="language-html">not html
+  </code></pre>
+  <b id="grep_block">is html</b>
+  <p><span>Some </span><code>code span</code><span>.</span></p>
   <p><span>And </span><span as-html><blink>grep_span</blink></span><span>.</span></p>
+  <p><span>I can include external </span><span id="external_inline_grep">Yo!</span><span>.</span></p>
+  <div src=block.html include>
+  <div id="external_block">This is a block</div></div>
+  </div>
+  </div>
+  </div>
+  </div>
+  
+            </div>
+            <div id="slip-touch-controls">
+              <div class="slip-previous">←</div>
+              <div class="slip-fullscreen">⇱</div>
+              <div class="slip-next">→</div>
 
 $ cp carousel.html /tmp/

--- a/test/compiler/html_blocks.t/run.t
+++ b/test/compiler/html_blocks.t/run.t
@@ -3,6 +3,7 @@
 
   $ show_source html_blocks.html | grep grep_block
   <b id="grep_block">is html</b>
+  <b class="grep_block">is html</b>
 
   $ show_source html_blocks.html | grep grep_span
   <p><span>And </span><span as-html><blink>grep_span</blink></span><span>.</span></p>
@@ -10,27 +11,5 @@
   $ show_source html_blocks.html | grep "external_inline_grep"
   <p><span>I can include external </span><span id="external_inline_grep">Yo!</span><span>.</span></p>
 
-  $ show_source html_blocks.html | grep -C 10 "external_block"
-  <div class="slip">
-  <div class="slip-body">
-  <div src=html_blocks.md include>
-  <pre><code class="language-html">not html
-  </code></pre>
-  <b id="grep_block">is html</b>
-  <p><span>Some </span><code>code span</code><span>.</span></p>
-  <p><span>And </span><span as-html><blink>grep_span</blink></span><span>.</span></p>
-  <p><span>I can include external </span><span id="external_inline_grep">Yo!</span><span>.</span></p>
-  <div src=block.html include>
+  $ show_source html_blocks.html | grep "external_block"
   <div id="external_block">This is a block</div></div>
-  </div>
-  </div>
-  </div>
-  </div>
-  
-            </div>
-            <div id="slip-touch-controls">
-              <div class="slip-previous">←</div>
-              <div class="slip-fullscreen">⇱</div>
-              <div class="slip-next">→</div>
-
-$ cp carousel.html /tmp/

--- a/test/compiler/images.t/run.t
+++ b/test/compiler/images.t/run.t
@@ -1,5 +1,6 @@
 We can compile the file
 
+  $ export SLIPSHOW__SECRET__NO_ENGINE=TRUE
   $ slipshow compile slip.md
   warning: file 'img.png' could not be read: img.png: No such file or directory
       ┌─ slip.md:6:4

--- a/test/compiler/multi-file.t/run.t
+++ b/test/compiler/multi-file.t/run.t
@@ -1,5 +1,6 @@
 Let's compile the file and check file inclusion
 
+  $ export SLIPSHOW__SECRET__NO_ENGINE=TRUE
   $ slipshow compile main.md
 
 $ cp main.html /tmp/

--- a/test/compiler/multi-frontmatter.t/run.t
+++ b/test/compiler/multi-frontmatter.t/run.t
@@ -1,6 +1,7 @@
 Compatible multiple options are not reported (dimension, css files).
 Incompatible options are reported (math-mode)
 
+  $ export SLIPSHOW__SECRET__NO_ENGINE=TRUE
   $ slipshow compile main.md
   warning: Option 'math-mode' is assigned multiple times in incompatible ways
       ┌─ chapter1.md:4:11

--- a/test/compiler/pdf.t/run.t
+++ b/test/compiler/pdf.t/run.t
@@ -1,5 +1,6 @@
 We can compile the file using the slip_of_mark binary
 
+  $ export SLIPSHOW__SECRET__NO_ENGINE=TRUE
   $ slipshow compile pdf.md
 
 The pdf support is added:

--- a/test/compiler/simple.t/run.t
+++ b/test/compiler/simple.t/run.t
@@ -1,5 +1,6 @@
 We can compile the file using the slip_of_mark binary
 
+  $ export SLIPSHOW__SECRET__NO_ENGINE=TRUE
   $ slipshow compile -o file.html file.md
 
   $ show_source file.html | grep "<body>" -A 13
@@ -23,7 +24,7 @@ $ du -h file.html
 
 What happens if the file does not exists? There is an error message...
 
-  $ slipshow compile -o file.html non-existing-file.md
+  $ SLIPSHOW__SECRET__NO_ENGINE=TRUE slipshow compile -o file.html non-existing-file.md
   warning: file 'non-existing-file.md' could not be read: non-existing-file.md: No such file or directory
   
 

--- a/test/compiler/slides.t/run.t
+++ b/test/compiler/slides.t/run.t
@@ -1,5 +1,6 @@
 We can compile the file using the slip_of_mark binary
 
+  $ export SLIPSHOW__SECRET__NO_ENGINE=TRUE
   $ slipshow compile slides.md
 
   $ show_source slides.html | grep "<body>" -A 16

--- a/test/compiler/theme.t/run.t
+++ b/test/compiler/theme.t/run.t
@@ -1,5 +1,6 @@
 No theme provided or "theme:default" is the same
 
+  $ export SLIPSHOW__SECRET__NO_ENGINE=TRUE
   $ slipshow compile empty.md -o default_theme1.html
   $ slipshow compile default.md -o default_theme2.html
 


### PR DESCRIPTION
Markdown has complex rules to detect raw html. Sometimes it is easier to have a dedicated syntax rather than relying on this detection.

Also, adds the ability to include external html using either `![](file.html)` (for inlines) or `{include src=file.html}` (for blocks).