### PR TITLE
Fix lsp action detection in multifile settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
   - Two commands to make the presentation preview go forward/backward from the
     editor (#242)
 
+### Fixed
+
+- Fix action detection in LSP in multifile settings (#243)
+
 ## [v0.11.0] Brazlip (Sunday, the 24th of May, 2026)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## unrelease
+## unreleased
 
 ### Added
 

--- a/src/lspishow/current_ast.ml
+++ b/src/lspishow/current_ast.ml
@@ -1,44 +1,47 @@
 let ast : Slipshow.Ast.t option ref = ref None
 let set_ast x = ast := Some x
 
-let pos_in_textloc ?(permissive = false) ~(pos : Linol_lwt.Position.t) ~loc () =
+let pos_in_textloc ~path ?(permissive = false) ~(pos : Linol_lwt.Position.t)
+    ~loc () =
   let ( <? ) = if permissive then ( <= ) else ( < ) in
   let range = loc in
   let range = Diagnostic.linoloc_of_textloc range in
   (* Format.eprintf "is %d:%d in %d:%d -> %d:%d?\n" pos.line pos.character *)
   (*   range.start.line range.start.character range.end_.line range.end_.character; *)
   let res =
-    ((range.start.line = pos.line && range.start.character <= pos.character)
-    || range.start.line < pos.line)
+    Fpath.equal (Fpath.normalize path)
+      (Fpath.normalize @@ Fpath.v @@ Cmarkit.Textloc.file loc)
+    && ((range.start.line = pos.line && range.start.character <= pos.character)
+       || range.start.line < pos.line)
     && ((range.end_.line = pos.line && pos.character <? range.end_.character)
        || pos.line < range.end_.line)
   in
   (* Format.eprintf "%s\n%!" (if res then "yes" else "no"); *)
   res
 
-let pos_in ~(pos : Linol_lwt.Position.t) ~meta =
+let pos_in ~path ~(pos : Linol_lwt.Position.t) ~meta =
   let loc = Cmarkit.Meta.textloc meta in
-  pos_in_textloc ~pos ~loc
+  pos_in_textloc ~path ~pos ~loc
 
-let pos_in_inline inline ~pos =
+let pos_in_inline ~path inline ~pos =
   let meta = Slipshow.Ast.Utils.Inline.meta inline in
   let attrs = Slipshow.Ast.Utils.Inline.get_attribute inline in
   let is_in_attrs =
     match attrs with
     | None -> false
-    | Some (_, (_, meta)) -> pos_in ~pos ~meta ()
+    | Some (_, (_, meta)) -> pos_in ~path ~pos ~meta ()
   in
-  is_in_attrs || pos_in ~pos ~meta ()
+  is_in_attrs || pos_in ~path ~pos ~meta ()
 
-let pos_in_block block ~pos =
+let pos_in_block ~path block ~pos =
   let meta = Slipshow.Ast.Utils.Block.meta block in
   let attrs = Slipshow.Ast.Utils.Block.get_attribute block in
   let is_in_attrs =
     match attrs with
     | None -> false
-    | Some (_, (_, meta)) -> pos_in ~pos ~meta ()
+    | Some (_, (_, meta)) -> pos_in ~path ~pos ~meta ()
   in
-  is_in_attrs || pos_in ~pos ~meta ()
+  is_in_attrs || pos_in ~path ~pos ~meta ()
 
 open Cmarkit
 
@@ -57,8 +60,8 @@ type trace = {
   block : block_trace;
 }
 
-let enter_attrs acc pos attrs =
-  let pos_in ~meta = pos_in ~permissive:true ~pos ~meta () in
+let enter_attrs ~path acc pos attrs =
+  let pos_in ~meta = pos_in ~path ~permissive:true ~pos ~meta () in
   let kv =
     let kv = Cmarkit.Attributes.kv_attributes attrs in
     List.find_map
@@ -86,16 +89,16 @@ let enter_attrs acc pos attrs =
   in
   { acc with attribute }
 
-let rec enter_inline acc pos (inline : Cmarkit.Inline.t) =
+let rec enter_inline ~path acc pos (inline : Cmarkit.Inline.t) =
   let acc = { acc with inline = inline :: acc.inline } in
   let may_enter i =
-    if pos_in_inline ~pos i then enter_inline acc pos i else acc
+    if pos_in_inline ~path ~pos i then enter_inline ~path acc pos i else acc
   in
   let attrs = Slipshow.Ast.Utils.Inline.get_attribute inline in
   let attrs =
     match attrs with
-    | Some (_, (attrs, meta)) when pos_in ~pos ~meta () ->
-        Some (enter_attrs acc pos attrs)
+    | Some (_, (attrs, meta)) when pos_in ~path ~pos ~meta () ->
+        Some (enter_attrs ~path acc pos attrs)
     | _ -> None
   in
   (fun f -> match attrs with Some x -> x | None -> f ()) @@ fun () ->
@@ -107,10 +110,10 @@ let rec enter_inline acc pos (inline : Cmarkit.Inline.t) =
       acc
   | Strong_emphasis ((em, _), _) | Emphasis ((em, _), _) ->
       let i = Emphasis.inline em in
-      enter_inline acc pos i
+      enter_inline ~path acc pos i
   | Inlines (is, _) -> (
-      let next = List.find_opt (pos_in_inline ~pos) is in
-      match next with None -> acc | Some i -> enter_inline acc pos i)
+      let next = List.find_opt (pos_in_inline ~path ~pos) is in
+      match next with None -> acc | Some i -> enter_inline ~path acc pos i)
   | Image ((link, _), _) | Link ((link, _), _) ->
       let i = Link.text link in
       may_enter i
@@ -134,13 +137,13 @@ let rec enter_inline acc pos (inline : Cmarkit.Inline.t) =
 (*   let meta = Slipshow.Ast.Utils.Inline.meta inline in *)
 (*   if pos_in ~pos ~meta then enter_inline pos inline else None *)
 
-let rec enter_block acc pos (block : Cmarkit.Block.t) =
+let rec enter_block ~path acc pos (block : Cmarkit.Block.t) =
   let open Cmarkit.Block in
   let attrs = Slipshow.Ast.Utils.Block.get_attribute block in
   let attrs =
     match attrs with
-    | Some (_, (attrs, meta)) when pos_in ~pos ~meta () ->
-        Some (enter_attrs acc pos attrs)
+    | Some (_, (attrs, meta)) when pos_in ~path ~pos ~meta () ->
+        Some (enter_attrs ~path acc pos attrs)
     | _ -> None
   in
   (fun f -> match attrs with Some x -> x | None -> f ()) @@ fun () ->
@@ -153,62 +156,71 @@ let rec enter_block acc pos (block : Cmarkit.Block.t) =
   | Ext_attribute_definition _ ->
       (* TODO *)
       acc
-  | Ext_standalone_attributes (attrs, _) -> enter_attrs acc pos attrs
+  | Ext_standalone_attributes (attrs, _) -> enter_attrs ~path acc pos attrs
   | Heading ((h, _attrs), _) ->
       let inline = Heading.inline h in
-      if pos_in_inline ~pos inline then enter_inline acc pos inline else acc
+      if pos_in_inline ~path ~pos inline then enter_inline ~path acc pos inline
+      else acc
   | Block_quote ((bq, _attrs), _) ->
       let b = Block_quote.block bq in
-      if pos_in_block ~pos b then enter_block acc pos b else acc
+      if pos_in_block ~path ~pos b then enter_block ~path acc pos b else acc
   | Blocks (bs, _) -> (
-      let next = List.find_opt (pos_in_block ~pos) bs in
-      match next with None -> acc | Some b -> enter_block acc pos b)
+      let next = List.find_opt (pos_in_block ~path ~pos) bs in
+      match next with None -> acc | Some b -> enter_block ~path acc pos b)
   | List ((l, _attrs), _) ->
       let lis = List'.items l in
       let ( let+ ) x f = match x with None -> acc | Some x -> f x in
-      let+ li, _ = List.find_opt (fun (_, meta) -> pos_in ~pos ~meta ()) lis in
+      let+ li, _ =
+        List.find_opt (fun (_, meta) -> pos_in ~path ~pos ~meta ()) lis
+      in
       let block = List_item.block li in
-      if pos_in_block block ~pos then enter_block acc pos block else acc
+      if pos_in_block ~path block ~pos then enter_block ~path acc pos block
+      else acc
   | Paragraph ((p, _attrs), _) ->
       let inline = Paragraph.inline p in
-      if pos_in_inline ~pos inline then enter_inline acc pos inline else acc
+      if pos_in_inline ~path ~pos inline then enter_inline ~path acc pos inline
+      else acc
   | Slipshow.Ast.S_block b -> (
       match b with
       | Included _ -> acc
       | IncludedHTML _ -> acc
       | Slip ((block, _), _) | Div ((block, _), _) ->
-          if pos_in_block block ~pos then enter_block acc pos block else acc
+          if pos_in_block ~path block ~pos then enter_block ~path acc pos block
+          else acc
       | Slide ((slide, _), _) ->
           (* TODO: title *)
           let block = slide.content in
-          if pos_in_block block ~pos then enter_block acc pos block else acc
+          if pos_in_block ~path block ~pos then enter_block ~path acc pos block
+          else acc
       | MermaidJS _ | SlipScript _ -> acc
       | Carousel ((bs, _), _) -> (
-          let next = List.find_opt (pos_in_block ~pos) bs in
-          match next with None -> acc | Some b -> enter_block acc pos b))
+          let next = List.find_opt (pos_in_block ~path ~pos) bs in
+          match next with None -> acc | Some b -> enter_block ~path acc pos b))
   | _ -> assert false
 
-let get_leave pos doc =
+let get_leave ~path pos doc =
   let acc = { attribute = None; inline = []; block = [] } in
   let block = Cmarkit.Doc.block doc in
-  if pos_in_block block ~pos then enter_block acc pos block else acc
+  if pos_in_block ~path block ~pos then enter_block ~path acc pos block else acc
 
-let get_target pos (action_plan : Slipshow.Ast.Action_plan.t) =
+let get_target ~path pos (action_plan : Slipshow.Ast.Action_plan.t) =
   List.find_map
     (fun { Slipshow.Ast.Action_plan.actions; attrs = _, meta; _ } ->
-      if not @@ pos_in ~pos ~meta () then None
+      if not @@ pos_in ~path ~pos ~meta () then None
       else
         List.find_map
           (fun (arg, (_, value)) ->
             Option.bind value @@ fun (_, meta) ->
             let loc = Cmarkit.Meta.textloc meta in
-            if not @@ pos_in_textloc ~permissive:true ~pos ~loc () then None
+            if not @@ pos_in_textloc ~path ~permissive:true ~pos ~loc () then
+              None
             else
               let targets = Slipshow.Action_plan.targets arg in
               List.find_map
                 (fun (t, ploc) ->
                   let loc = Diagnosis.loc_of_ploc loc ploc in
-                  if pos_in_textloc ~permissive:true ~pos ~loc () then Some t
+                  if pos_in_textloc ~path ~permissive:true ~pos ~loc () then
+                    Some t
                   else None)
                 targets)
           actions)

--- a/src/lspishow/lspishow.ml
+++ b/src/lspishow/lspishow.ml
@@ -284,7 +284,7 @@ class lsp_server =
         let+ x = Slipshow.Id_map.SMap.find_opt id ast.id_map in
         let meta = snd (Slipshow.Id_map.Unionable_set.get x.definition).id in
         let loc = Cmarkit.Meta.textloc meta in
-        let file = Fpath.v (Cmarkit.Textloc.file loc) in
+        let file = Cmarkit.Textloc.file loc |> Fpath.v |> Fpath.normalize in
         Format.eprintf "Going to location %a%!\n" Fpath.pp file;
         let uri = file |> Fpath.to_string |> Linol_lsp.Uri0.of_string in
         let range = Diagnostic.linoloc_of_textloc loc in
@@ -374,7 +374,9 @@ class lsp_server =
         List.filter_map
           (fun loc ->
             let loc_in_file loc =
-              let path1 = Fpath.v (Cmarkit.Textloc.file loc) in
+              let path1 =
+                Cmarkit.Textloc.file loc |> Fpath.v |> Fpath.normalize
+              in
               let path2 = Fpath.normalize path in
               Fpath.equal path1 path2
             in

--- a/src/lspishow/lspishow.ml
+++ b/src/lspishow/lspishow.ml
@@ -56,10 +56,10 @@ module State = struct
   let rev_deps_from_fs (file : Fpath.t) =
     Lwt_mutex.with_lock mutex @@ fun () ->
     Format.eprintf "update_from_fs with file = %a\n%!" Fpath.pp file;
-    let parent, filename = Fpath.split_base file in
+    let parent = Fpath.parent file in
     let read_file = Read_file.v parent in
     let () =
-      let new_unit = Slipshow.Compile.unit ~read_file filename in
+      let new_unit = Slipshow.Compile.unit ~read_file file in
       Rev_deps.update_state ~old_unit:None ~new_unit file
     in
     Lwt.return_unit
@@ -75,9 +75,9 @@ module State = struct
     | Some { source = old_source; _ } when String.equal source old_source ->
         Lwt.return `No_changes
     | old ->
-        let parent, filename = Fpath.split_base file in
-        let read_file = Read_file.v parent |> Read_file.with_ filename source in
-        let unit = Slipshow.Compile.unit ~read_file filename in
+        let parent = Fpath.parent file in
+        let read_file = Read_file.v parent |> Read_file.with_ file source in
+        let unit = Slipshow.Compile.unit ~read_file file in
         let new_ = { source; unit } in
         update_state ~old ~new_ file;
         Lwt.return `Update
@@ -88,11 +88,11 @@ module State = struct
       buffers Fpath.Map.empty
 
   let update_root root =
-    let parent, filename = Fpath.split_base root in
+    let parent = Fpath.parent root in
     let read_file = Read_file.v parent in
     let units = units_of_buffer () in
     let units, diagnostics =
-      Slipshow.Compile.compile_all ~read_file units filename
+      Slipshow.Compile.compile_all ~read_file units root
     in
     let condition =
       match Hashtbl.find_opt roots_state root with

--- a/src/lspishow/lspishow.ml
+++ b/src/lspishow/lspishow.ml
@@ -284,11 +284,7 @@ class lsp_server =
         let+ x = Slipshow.Id_map.SMap.find_opt id ast.id_map in
         let meta = snd (Slipshow.Id_map.Unionable_set.get x.definition).id in
         let loc = Cmarkit.Meta.textloc meta in
-        let file =
-          Fpath.normalize
-          @@ Fpath.( // ) (Fpath.parent root)
-               (Fpath.v (Cmarkit.Textloc.file loc))
-        in
+        let file = Fpath.v (Cmarkit.Textloc.file loc) in
         Format.eprintf "Going to location %a%!\n" Fpath.pp file;
         let uri = file |> Fpath.to_string |> Linol_lsp.Uri0.of_string in
         let range = Diagnostic.linoloc_of_textloc loc in
@@ -378,11 +374,7 @@ class lsp_server =
         List.filter_map
           (fun loc ->
             let loc_in_file loc =
-              let path1 =
-                Fpath.normalize
-                @@ Fpath.( // ) (Fpath.parent root)
-                     (Fpath.v (Cmarkit.Textloc.file loc))
-              in
+              let path1 = Fpath.v (Cmarkit.Textloc.file loc) in
               let path2 = Fpath.normalize path in
               Fpath.equal path1 path2
             in

--- a/src/lspishow/lspishow.ml
+++ b/src/lspishow/lspishow.ml
@@ -255,7 +255,7 @@ class lsp_server =
         let* root = Rev_deps.get_roots path |> Fpath.Set.choose_opt in
         let* { units = ast; _ } = Hashtbl.find_opt State.roots_state root in
         let+ () =
-          Current_ast.get_target pos ast.action_plan |> Option.map ignore
+          Current_ast.get_target ~path pos ast.action_plan |> Option.map ignore
           (* Just as a way to test we are in the context of a target. Later, it
              would be even better to filter the IDs using what the action
              expects (eg, only show ids for slip-script in an exec action) *)
@@ -280,7 +280,7 @@ class lsp_server =
       let res =
         let* root = Rev_deps.get_roots path |> Fpath.Set.choose_opt in
         let* { units = ast; _ } = Hashtbl.find_opt State.roots_state root in
-        let* id = Current_ast.get_target pos ast.action_plan in
+        let* id = Current_ast.get_target ~path pos ast.action_plan in
         let+ x = Slipshow.Id_map.SMap.find_opt id ast.id_map in
         let meta = snd (Slipshow.Id_map.Unionable_set.get x.definition).id in
         let loc = Cmarkit.Meta.textloc meta in
@@ -305,7 +305,7 @@ class lsp_server =
         let path = uri |> Linol_lwt.DocumentUri.to_path |> Fpath.v in
         let* buffer = Hashtbl.find_opt State.buffers path in
         let* tail_attrs =
-          let trail = Current_ast.get_leave pos buffer.unit.ast in
+          let trail = Current_ast.get_leave ~path pos buffer.unit.ast in
           trail.attribute
         in
         match tail_attrs with
@@ -356,13 +356,15 @@ class lsp_server =
         let* { units = ast; _ } = Hashtbl.find_opt State.roots_state root in
         let* buffer = Hashtbl.find_opt State.buffers path in
         let* id =
-          let res1 = Current_ast.get_target params.position ast.action_plan in
+          let res1 =
+            Current_ast.get_target ~path params.position ast.action_plan
+          in
           match res1 with
           | Some _ -> res1
           | None -> (
               let* tail_attrs =
                 let trail =
-                  Current_ast.get_leave params.position buffer.unit.ast
+                  Current_ast.get_leave ~path params.position buffer.unit.ast
                 in
                 trail.attribute
               in


### PR DESCRIPTION
The completion, definition and highlight LSP feature did not take into account the current file we are in, leading to incorrect behaviour. This PR fixes that.