### PR TITLE
Fix external themes in serve mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Fixed
 
 - Fix action detection in LSP in multifile settings (#243)
+- Fix external themes in serve mode (#245)
 
 ## [v0.11.0] Brazlip (Sunday, the 24th of May, 2026)
 

--- a/src/cli/run.ml
+++ b/src/cli/run.ml
@@ -91,7 +91,7 @@ let serve ~input ~output ~port =
         Slipshow.Compile.compile_all ~read_file Fpath.Map.empty input
       in
       let result' =
-        Slipshow.delayed_from_units ~has_speaker_view:true ~read_file result
+        Slipshow.delayed_from_units ~has_speaker_view:true result
       in
       let html = Slipshow.add_starting_state result' None in
       let+ () = Io.write output html in

--- a/src/compiler/frontmatter.ml
+++ b/src/compiler/frontmatter.ml
@@ -28,7 +28,7 @@ let external_ids_key = "external-ids"
 module Global = struct
   type t = {
     math_link : Asset.t loced option;
-    theme : [ `Builtin of Themes.t | `External of string ] loced option;
+    theme : [ `Builtin of Themes.t | `External of Asset.t ] loced option;
     dimension : (int * int) loced option;
     highlightjs_theme : string loced option;
     math_mode : [ `Mathjax | `Katex ] loced option;
@@ -164,15 +164,17 @@ module Math_link = struct
 end
 
 module Theme = struct
-  type t = [ `Builtin of Themes.t | `External of string ] loced
+  type t = [ `Builtin of Themes.t | `External of Asset.t ] loced
 
   let key = theme_key
   let default = (`Builtin Themes.Default, Cmarkit.Textloc.none)
 
-  let of_string ~to_asset:_ (s, loc) =
+  let of_string ~to_asset (s, loc) =
     match Themes.of_string s with
     | Some theme -> Ok (`Builtin theme, loc)
-    | None -> Ok (`External s, loc)
+    | None ->
+        let theme = to_asset s in
+        Ok (`External theme, loc)
 
   let update_frontmatter (fm : fm) v =
     let theme = combine_opt key (Some v) fm.global.theme in

--- a/src/compiler/frontmatter.mli
+++ b/src/compiler/frontmatter.mli
@@ -11,7 +11,7 @@ end
 module Global : sig
   type t = {
     math_link : Asset.t loced option;
-    theme : [ `Builtin of Themes.t | `External of string ] loced option;
+    theme : [ `Builtin of Themes.t | `External of Asset.t ] loced option;
     dimension : (int * int) loced option;
     highlightjs_theme : string loced option;
     math_mode : [ `Mathjax | `Katex ] loced option;
@@ -61,7 +61,7 @@ module Math_link : Field with type t = Asset.t loced
 
 module Theme :
   Field_with_default
-    with type t = [ `Builtin of Themes.t | `External of string ] loced
+    with type t = [ `Builtin of Themes.t | `External of Asset.t ] loced
 
 module Css_links : Field with type t = Asset.t list
 module Js_links : Field with type t = Asset.t list

--- a/src/compiler/slipshow.ml
+++ b/src/compiler/slipshow.ml
@@ -266,7 +266,7 @@ let to_grace htbl_include er =
 let to_grace units errors = List.map (to_grace units.Ast.units) errors
 
 let delayed_from_units ?(options = Frontmatter.Global.empty) ?slipshow_js
-    ?(read_file = fun _ -> Ok None) ~has_speaker_view units =
+    ~has_speaker_view units =
   let options = Frontmatter.Global.combine options units.Ast.options in
   let ast = { units with options } in
   let dimension =
@@ -279,21 +279,12 @@ let delayed_from_units ?(options = Frontmatter.Global.empty) ?slipshow_js
   let math_mode =
     Option.value ~default:Frontmatter.Math_mode.default options.math_mode |> fst
   in
-  let resolve_theme = function
-    | `Builtin _ as x -> x
-    | `External x ->
-        let asset = Asset.of_string ~read_file x in
-        `External asset
+  let theme, _loc =
+    Option.value ~default:Frontmatter.Theme.default options.theme
   in
-  let theme =
-    match options.theme with
-    | None -> resolve_theme (fst Frontmatter.Theme.default)
-    | Some t -> resolve_theme (fst t)
-  in
-  let highlightjs_theme =
+  let highlightjs_theme, _loc =
     Option.value ~default:Frontmatter.Hljs_theme.default
       options.highlightjs_theme
-    |> fst
   in
   let math_link = options.math_link |> Option.map fst in
   let content = Renderers.to_html_string ast in
@@ -308,9 +299,7 @@ let delayed_from_units ?(options = Frontmatter.Global.empty) ?slipshow_js
 let delayed ?options ?slipshow_js ~read_file ~has_speaker_view file =
   let units, errors = Compile.compile_all Fpath.Map.empty file ~read_file in
   let warnings = to_grace units errors in
-  let res =
-    delayed_from_units ?options ?slipshow_js ~read_file ~has_speaker_view units
-  in
+  let res = delayed_from_units ?options ?slipshow_js ~has_speaker_view units in
   (res, warnings)
 
 let add_starting_state ?(autofocus = true) (start, end_, has_speaker_view)

--- a/src/compiler/slipshow.mli
+++ b/src/compiler/slipshow.mli
@@ -28,7 +28,6 @@ type file_reader = Fpath.t -> (string option, [ `Msg of string ]) result
 val delayed_from_units :
   ?options:Frontmatter.Global.t ->
   ?slipshow_js:Asset.t ->
-  ?read_file:file_reader ->
   has_speaker_view:bool ->
   Ast.units ->
   delayed


### PR DESCRIPTION
We need to resolve the theme _before_ it being delayed. The un-delaying is done in the browser client, which does not have access to file system.