### PR TITLE
Fill units in full, while still preventing loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - Fix action detection in LSP in multifile settings (#243)
 - Fix external themes in serve mode (#245)
+- Fix LSP preview with multiple files when some of them are not opened (#250)
 
 ## [v0.11.0] Brazlip (Sunday, the 24th of May, 2026)
 

--- a/src/compiler/compile.ml
+++ b/src/compiler/compile.ml
@@ -623,20 +623,27 @@ let unit ?locs ~read_file file =
   let doc, frontmatter = Cmarkit_proxy.of_string ~read_file ~file s in
   of_cmarkit ~source ~path:file doc ~fm:frontmatter
 
-let rec add_to_compile ?locs file units ~read_file =
-  if Fpath.Map.mem file units then units
+let rec add_to_compile ?locs ~visited file units ~read_file =
+  if Fpath.Set.mem file visited then (units, visited)
   else
-    let u = unit ~read_file ?locs file in
+    let visited = Fpath.Set.add file visited in
+    let u =
+      match Fpath.Map.find_opt file units with
+      | Some u -> u
+      | None -> unit ~read_file ?locs file
+    in
     let units = Fpath.Map.add file u units in
     let c =
       Fpath.Map.fold
-        (fun dep locs c -> add_to_compile ~locs dep c ~read_file)
-        u.deps units
+        (fun dep locs (c, visited) ->
+          add_to_compile ~locs ~visited dep c ~read_file)
+        u.deps (units, visited)
     in
     c
 
 let compile_all ~read_file units file =
-  let units = add_to_compile file units ~read_file in
+  let visited = Fpath.Set.empty in
+  let units, _visited = add_to_compile file units ~visited ~read_file in
   let files, options =
     Ast.Folder.fold_just_units
       (fun unit (files, option) ->


### PR DESCRIPTION
When calling `compile_all`, in some cases (LSP buffers) we might pass a list of units that include the one we want to compile (the "root"), but not some of its dependencies. So we want to traverse its dependencies (but still not loop).