### PR TITLE
Watch files through the LSP server (unless they are opened)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   - Consider `.slp` as input files. (#244)
   - A configuration for refreshing the preview on each key stroke, or on
     save. (#248)
+  - Watch dependencies for change and refresh preview (#252)
 
 ### Changed
 

--- a/src/lspishow/buffers.ml
+++ b/src/lspishow/buffers.ml
@@ -25,10 +25,9 @@ let update_root root =
   ()
 
 (** Update the root of an updated buffer *)
-let update_state ~old ~new_ file =
+let update_state ~new_ file =
   Hashtbl.replace buffers file new_;
-  let old_unit = Option.map (fun old -> old.unit) old in
-  Rev_deps.update_state ~old_unit ~new_unit:new_.unit file
+  Rev_deps.update_state ~new_unit:new_.unit file
 
 let update file source =
   match Hashtbl.find_opt buffers file with
@@ -40,12 +39,12 @@ let update file source =
         | Some _ -> ()
       in
       Fpath.Set.iter compile_missing_roots rs
-  | old ->
+  | _ ->
       let parent = Fpath.parent file in
       let open Read_file.Syntax in
       let read_file = Read_file.with_ file source ||| read_file parent in
       let unit = Slipshow.Compile.unit ~read_file file in
       let new_ = { source; unit } in
-      update_state ~old ~new_ file;
+      update_state ~new_ file;
       let roots = Rev_deps.get_roots file in
       roots |> Fpath.Set.iter update_root

--- a/src/lspishow/lspishow.ml
+++ b/src/lspishow/lspishow.ml
@@ -494,7 +494,11 @@ class lsp_server =
             ()
           end
         in
-        Hashtbl.iter update_root_if_needed Roots.buffers
+        (* In [update_root_if_needed] we are going to modify [Roots.buffers], so
+           we "snapshot" it before traversing it. Even though in principle it is
+           probably ok, since we only replace values, not add new ones. *)
+        let buffers = Roots.buffers |> Hashtbl.to_seq |> Fpath.Map.of_seq in
+        Fpath.Map.iter update_root_if_needed buffers
       in
       Lwt_list.iter_s handle_file_event changes
 

--- a/src/lspishow/lspishow.ml
+++ b/src/lspishow/lspishow.ml
@@ -464,7 +464,7 @@ class lsp_server =
         in
         asset_deps () || unit_deps ()
       in
-      let handle_file_event { Linol_lwt.FileEvent.type_ = _; uri } =
+      let handle_file_event { Linol_lwt.FileEvent.type_; uri } =
         let path = uri |> Linol_lwt.DocumentUri.to_path |> Fpath.v in
         let check_is_not_a_buffer f =
           if Fpath.Map.mem path (Buffers.to_units ()) then Lwt.return_unit
@@ -472,10 +472,14 @@ class lsp_server =
         in
         check_is_not_a_buffer @@ fun () ->
         let+ () =
-          if is_slipshow_file path then State.rev_deps_from_fs path
+          ignore type_;
+          if is_slipshow_file path then
+            match type_ with
+            | Deleted -> Lwt.return @@ Rev_deps.remove path
+            | Created | Changed -> State.rev_deps_from_fs path
           else Lwt.return_unit
         in
-        let update_root_of_needed root_path (root : Slipshow_server.root) =
+        let update_root_if_needed root_path (root : Slipshow_server.root) =
           (* Update root for saved files *)
           let needs_updating = root_has_path_as_deps root path in
           if needs_updating then begin
@@ -490,7 +494,7 @@ class lsp_server =
             ()
           end
         in
-        Hashtbl.iter update_root_of_needed Roots.buffers
+        Hashtbl.iter update_root_if_needed Roots.buffers
       in
       Lwt_list.iter_s handle_file_event changes
 

--- a/src/lspishow/lspishow.ml
+++ b/src/lspishow/lspishow.ml
@@ -318,9 +318,26 @@ class lsp_server =
           ()
       | _ -> decode_payload conf
 
+    method private register_capability
+        ~(notify_back : Linol_lwt.Jsonrpc2.notify_back) id ~registerOptions
+        ~method_ =
+      let ( let> ) cont f = cont f in
+      let server_request =
+        let registrations =
+          [ Linol_lwt.Registration.create ~id ~registerOptions ~method_ () ]
+        in
+        let params = Linol_lwt.RegistrationParams.create ~registrations in
+        Linol_lsp.Server_request.ClientRegisterCapability params
+      in
+      let> res = notify_back#send_request server_request in
+      match res with
+      | Ok () -> Lwt.return ()
+      | Error _ ->
+          (* TODO: display error somewhere *)
+          Lwt.return ()
+
     method private register_conf_changes
         ~(notify_back : Linol_lwt.Jsonrpc2.notify_back) =
-      let ( let> ) cont f = cont f in
       (* {:https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_configuration}
 
           This pull model replaces the old push model were the client
@@ -345,31 +362,50 @@ class lsp_server =
                 };
             _;
           } ->
-          let id = "didchangeconfid" in
-          let server_request =
-            let registrations =
-              [
-                Linol_lwt.Registration.create ~id ~registerOptions:(`Assoc [])
-                  ~method_:"workspace/didChangeConfiguration" ();
-              ]
-            in
-            let params = Linol_lwt.RegistrationParams.create ~registrations in
-            Linol_lsp.Server_request.ClientRegisterCapability params
-          in
           let+ _ : Linol_jsonrpc.Jsonrpc.Id.t =
-            let> res = notify_back#send_request server_request in
-            match res with
-            | Ok () -> Lwt.return ()
-            | Error _ ->
-                (* TODO: display error somewhere *)
-                Lwt.return ()
+            let id = "did-change-conf-id" in
+            let registerOptions = `Assoc [] in
+            let method_ = "workspace/didChangeConfiguration" in
+            self#register_capability ~notify_back id ~registerOptions ~method_
+          in
+          ()
+      | _ -> Lwt.return ()
+
+    method private register_file_watching
+        ~(notify_back : Linol_lwt.Jsonrpc2.notify_back) =
+      match !client_capabilities with
+      | Some
+          {
+            workspace =
+              Some
+                {
+                  didChangeWatchedFiles =
+                    Some { dynamicRegistration = Some true; _ };
+                  _;
+                };
+            _;
+          } ->
+          let+ _ : Linol_jsonrpc.Jsonrpc.Id.t =
+            let id = "watching-all-files" in
+            let registerOptions =
+              let globPattern = `Pattern "**" in
+              let watchers =
+                [ Linol_lwt.FileSystemWatcher.create ~globPattern () ]
+              in
+              let open Linol_lwt.DidChangeWatchedFilesRegistrationOptions in
+              let options = create ~watchers in
+              yojson_of_t options
+            in
+            let method_ = "workspace/didChangeWatchedFiles" in
+            self#register_capability ~notify_back id ~registerOptions ~method_
           in
           ()
       | _ -> Lwt.return ()
 
     method private on_initialized ~notify_back () =
-      let _ : unit Lwt.t = self#register_conf_changes ~notify_back in
-      let* _ = self#update_configuration ~notify_back in
+      let* _ : unit = self#register_conf_changes ~notify_back in
+      let _ : unit Lwt.t = self#register_file_watching ~notify_back in
+      let _ : unit Lwt.t = self#update_configuration ~notify_back in
       Lwt.return ()
 
     method private update_configuration ~notify_back =
@@ -406,13 +442,39 @@ class lsp_server =
       let () = self#receive_config ~notify_back conf in
       Lwt.return ()
 
+    method private on_change_watched_files ~notify_back:_ change_watched_files =
+      let changes =
+        change_watched_files.Linol_lwt.DidChangeWatchedFilesParams.changes
+      in
+      Format.eprintf "Change watched file\n%!";
+      List.iter
+        (fun { Linol_lwt.FileEvent.type_ = _; uri } ->
+          let path = uri |> Linol_lwt.DocumentUri.to_path |> Fpath.v in
+          Format.eprintf "Change path is %a\n%!" Fpath.pp path;
+          Hashtbl.iter
+            (fun _root_path (root : Slipshow_server.root) ->
+              let found =
+                Fpath.Map.fold
+                  (fun p _ found ->
+                    (* TODO: Check if file in opened in buffers and slp or md extension *)
+                    Format.eprintf "Comparing path %a with deps path %a\n%!"
+                      Fpath.pp path Fpath.pp p;
+                    found || Fpath.equal p path)
+                  root.units.files false
+              in
+              if found then () (* TODO: trigger recompilation and refresh *))
+            Roots.buffers)
+        changes;
+      Lwt.return ()
+
     method! on_notification_unhandled ~notify_back
         (r : Linol_lsp.Client_notification.t) : unit Lwt.t =
       match r with
-      | Linol.Lsp.Client_notification.Initialized ->
-          self#on_initialized ~notify_back ()
-      | Linol.Lsp.Client_notification.ChangeConfiguration change_conf_params ->
+      | Initialized -> self#on_initialized ~notify_back ()
+      | ChangeConfiguration change_conf_params ->
           self#on_change_configuration ~notify_back change_conf_params
+      | DidChangeWatchedFiles change_watched_files ->
+          self#on_change_watched_files ~notify_back change_watched_files
       | r -> super#on_notification_unhandled ~notify_back r
 
     method on_notif_doc_did_open ~notify_back doc ~content : unit Linol_lwt.t =

--- a/src/lspishow/lspishow.ml
+++ b/src/lspishow/lspishow.ml
@@ -56,11 +56,12 @@ let diagnostics file : Linol.Lsp.Types.Diagnostic.t list option =
       | Some { diagnostics = errors; _ } ->
           Some (List.concat_map (Diagnostic.of_error ~root ~file) errors))
 
+let is_slipshow_file p = Fpath.has_ext "md" p || Fpath.has_ext "slp" p
+
 (* Find all markdown files in the given directory (recursing over subdirectories) *)
 let find_markdown_files path =
   Bos.OS.Dir.fold_contents ~traverse:`Any
-    ~elements:
-      (`Sat (fun p -> Ok (Fpath.has_ext "md" p || Fpath.has_ext "slp" p)))
+    ~elements:(`Sat (fun p -> Ok (is_slipshow_file p)))
     (fun p acc -> p :: acc)
     [] path
 
@@ -466,10 +467,15 @@ class lsp_server =
       let handle_file_event { Linol_lwt.FileEvent.type_ = _; uri } =
         let path = uri |> Linol_lwt.DocumentUri.to_path |> Fpath.v in
         let check_is_not_a_buffer f =
-          if Fpath.Map.mem path (Buffers.to_units ()) then () else f ()
+          if Fpath.Map.mem path (Buffers.to_units ()) then Lwt.return_unit
+          else f ()
         in
         check_is_not_a_buffer @@ fun () ->
-        let handle_root root_path (root : Slipshow_server.root) =
+        let+ () =
+          if is_slipshow_file path then State.rev_deps_from_fs path
+          else Lwt.return_unit
+        in
+        let update_root_of_needed root_path (root : Slipshow_server.root) =
           (* Update root for saved files *)
           let needs_updating = root_has_path_as_deps root path in
           if needs_updating then begin
@@ -484,10 +490,9 @@ class lsp_server =
             ()
           end
         in
-        Hashtbl.iter handle_root Roots.buffers
+        Hashtbl.iter update_root_of_needed Roots.buffers
       in
-      List.iter handle_file_event changes;
-      Lwt.return ()
+      Lwt_list.iter_s handle_file_event changes
 
     method! on_notification_unhandled ~notify_back
         (r : Linol_lsp.Client_notification.t) : unit Lwt.t =

--- a/src/lspishow/lspishow.ml
+++ b/src/lspishow/lspishow.ml
@@ -66,6 +66,7 @@ let find_markdown_files path =
     [] path
 
 let client_capabilities = ref None
+let rebounce = Hashtbl.create 10
 
 class lsp_server =
   object (self)
@@ -471,8 +472,20 @@ class lsp_server =
           else f ()
         in
         check_is_not_a_buffer @@ fun () ->
+        let debounce_id =
+          match Hashtbl.find_opt rebounce path with
+          | Some id -> id + 1
+          | None -> 0
+        in
+        let () = Hashtbl.replace rebounce path debounce_id in
+        let* () = Lwt_unix.sleep 1. in
+        let check_rebounce f =
+          match Hashtbl.find_opt rebounce path with
+          | Some id when Int.equal id debounce_id -> f ()
+          | _ -> Lwt.return_unit
+        in
+        check_rebounce @@ fun () ->
         let+ () =
-          ignore type_;
           if is_slipshow_file path then
             match type_ with
             | Deleted -> Lwt.return @@ Rev_deps.remove path

--- a/src/lspishow/lspishow.ml
+++ b/src/lspishow/lspishow.ml
@@ -451,7 +451,16 @@ class lsp_server =
         let asset_deps () =
           Fpath.Map.exists test_is_relevant root.units.files
         in
-        let unit_deps () = Fpath.Map.exists test_is_relevant root.units.units in
+        let unit_deps () =
+          Fpath.Map.exists
+            (fun p unit_ ->
+              test_is_relevant p unit_
+              (* We also test in the deps of the units, as an [{include}] of a
+                  missing unit will be in deps and not in units. Creating it
+                  should trigger a refresh *)
+              || Fpath.Map.exists test_is_relevant unit_.Slipshow.Ast.deps)
+            root.units.units
+        in
         asset_deps () || unit_deps ()
       in
       let handle_file_event { Linol_lwt.FileEvent.type_ = _; uri } =

--- a/src/lspishow/lspishow.ml
+++ b/src/lspishow/lspishow.ml
@@ -447,22 +447,41 @@ class lsp_server =
         change_watched_files.Linol_lwt.DidChangeWatchedFilesParams.changes
       in
       Format.eprintf "Change watched file\n%!";
+      let root_has_path_as_deps (root : Slipshow_server.root) path =
+        let test_is_relevant p _entry =
+          (* TODO: Check if file is opened in buffers and slp or md extension *)
+          Format.eprintf "Comparing path %a with deps path %a\n%!" Fpath.pp path
+            Fpath.pp p;
+          Fpath.equal p path
+        in
+        let asset_deps () =
+          Fpath.Map.exists test_is_relevant root.units.files
+        in
+        let unit_deps () = Fpath.Map.exists test_is_relevant root.units.units in
+        asset_deps () || unit_deps ()
+      in
       List.iter
         (fun { Linol_lwt.FileEvent.type_ = _; uri } ->
           let path = uri |> Linol_lwt.DocumentUri.to_path |> Fpath.v in
           Format.eprintf "Change path is %a\n%!" Fpath.pp path;
           Hashtbl.iter
-            (fun _root_path (root : Slipshow_server.root) ->
-              let found =
-                Fpath.Map.fold
-                  (fun p _ found ->
-                    (* TODO: Check if file in opened in buffers and slp or md extension *)
-                    Format.eprintf "Comparing path %a with deps path %a\n%!"
-                      Fpath.pp path Fpath.pp p;
-                    found || Fpath.equal p path)
-                  root.units.files false
-              in
-              if found then () (* TODO: trigger recompilation and refresh *))
+            (fun root_path (root : Slipshow_server.root) ->
+              (* Update root for saved files *)
+              let needs_updating = root_has_path_as_deps root path in
+              if needs_updating then begin
+                let parent = Fpath.parent root_path in
+                let _updated_root =
+                  Roots.update_root (Read_file.fs parent) Roots.saved
+                    Fpath.Map.empty root_path
+                in
+                (* Update root for buffers *)
+                let _updated_root =
+                  Roots.update_root (Buffers.read_file parent) Roots.buffers
+                    (Buffers.to_units ()) root_path
+                in
+                ()
+              end
+              (* TODO: trigger recompilation and refresh *))
             Roots.buffers)
         changes;
       Lwt.return ()

--- a/src/lspishow/lspishow.ml
+++ b/src/lspishow/lspishow.ml
@@ -37,7 +37,7 @@ module State = struct
     let read_file = Read_file.fs parent in
     let () =
       let new_unit = Slipshow.Compile.unit ~read_file file in
-      Rev_deps.update_state ~old_unit:None ~new_unit file
+      Rev_deps.update_state ~new_unit file
     in
     Lwt.return_unit
 

--- a/src/lspishow/lspishow.ml
+++ b/src/lspishow/lspishow.ml
@@ -112,13 +112,13 @@ class lsp_server =
       in
       let () =
         Format.eprintf "Here are the root of each markdown file\n%!";
-        Hashtbl.iter
+        Fpath.Map.iter
           (fun path paths ->
             Format.eprintf "%a -> [%s]\n%!" Fpath.pp path
               (String.concat " "
               @@ (paths |> Fpath.Set.to_seq |> List.of_seq
                 |> List.map Fpath.to_string)))
-          Rev_deps.current
+          Rev_deps.(as_map current)
       in
       super#on_req_initialize ~notify_back params
 

--- a/src/lspishow/lspishow.ml
+++ b/src/lspishow/lspishow.ml
@@ -446,44 +446,38 @@ class lsp_server =
       let changes =
         change_watched_files.Linol_lwt.DidChangeWatchedFilesParams.changes
       in
-      Format.eprintf "Change watched file\n%!";
       let root_has_path_as_deps (root : Slipshow_server.root) path =
-        let test_is_relevant p _entry =
-          (* TODO: Check if file is opened in buffers and slp or md extension *)
-          Format.eprintf "Comparing path %a with deps path %a\n%!" Fpath.pp path
-            Fpath.pp p;
-          Fpath.equal p path
-        in
+        let test_is_relevant p _entry = Fpath.equal p path in
         let asset_deps () =
           Fpath.Map.exists test_is_relevant root.units.files
         in
         let unit_deps () = Fpath.Map.exists test_is_relevant root.units.units in
         asset_deps () || unit_deps ()
       in
-      List.iter
-        (fun { Linol_lwt.FileEvent.type_ = _; uri } ->
-          let path = uri |> Linol_lwt.DocumentUri.to_path |> Fpath.v in
-          Format.eprintf "Change path is %a\n%!" Fpath.pp path;
-          Hashtbl.iter
-            (fun root_path (root : Slipshow_server.root) ->
-              (* Update root for saved files *)
-              let needs_updating = root_has_path_as_deps root path in
-              if needs_updating then begin
-                let parent = Fpath.parent root_path in
-                let _updated_root =
-                  Roots.update_root (Read_file.fs parent) Roots.saved
-                    Fpath.Map.empty root_path
-                in
-                (* Update root for buffers *)
-                let _updated_root =
-                  Roots.update_root (Buffers.read_file parent) Roots.buffers
-                    (Buffers.to_units ()) root_path
-                in
-                ()
-              end
-              (* TODO: trigger recompilation and refresh *))
-            Roots.buffers)
-        changes;
+      let handle_file_event { Linol_lwt.FileEvent.type_ = _; uri } =
+        let path = uri |> Linol_lwt.DocumentUri.to_path |> Fpath.v in
+        let check_is_not_a_buffer f =
+          if Fpath.Map.mem path (Buffers.to_units ()) then () else f ()
+        in
+        check_is_not_a_buffer @@ fun () ->
+        let handle_root root_path (root : Slipshow_server.root) =
+          (* Update root for saved files *)
+          let needs_updating = root_has_path_as_deps root path in
+          if needs_updating then begin
+            let parent = Fpath.parent root_path in
+            let _updated_root =
+              Roots.update_root (Read_file.fs parent) Roots.saved
+                Fpath.Map.empty root_path
+            and _updated_root_buffers =
+              Roots.update_root (Buffers.read_file parent) Roots.buffers
+                (Buffers.to_units ()) root_path
+            in
+            ()
+          end
+        in
+        Hashtbl.iter handle_root Roots.buffers
+      in
+      List.iter handle_file_event changes;
       Lwt.return ()
 
     method! on_notification_unhandled ~notify_back

--- a/src/lspishow/rev_deps.ml
+++ b/src/lspishow/rev_deps.ml
@@ -28,7 +28,7 @@ let get dependant =
   Hashtbl.find_opt current.rev_deps dependant
   |> Option.value ~default:Fpath.Set.empty
 
-let update_state ~new_unit file =
+let update_state ~new_deps file =
   let () =
     match Hashtbl.find_opt current.deps file with
     | None -> ()
@@ -41,20 +41,26 @@ let update_state ~new_unit file =
             remove dependant file)
           deps
   in
-  let () =
-    let new_deps =
-      new_unit.Slipshow.Ast.deps |> Fpath.Map.to_seq |> Seq.map fst
-      |> Fpath.Set.of_seq
-    in
-    Hashtbl.replace current.deps file new_deps
+  match new_deps with
+  | Some new_deps ->
+      Hashtbl.replace current.deps file new_deps;
+      Fpath.Set.iter
+        (fun dependant ->
+          let dependant =
+            Fpath.normalize @@ Fpath.( // ) (Fpath.parent file) dependant
+          in
+          add dependant file)
+        new_deps
+  | None -> Hashtbl.remove current.deps file
+
+let remove file = update_state ~new_deps:None file
+
+let update_state ~new_unit file =
+  let new_deps =
+    new_unit.Slipshow.Ast.deps |> Fpath.Map.to_seq |> Seq.map fst
+    |> Fpath.Set.of_seq |> Option.some
   in
-  Fpath.Map.iter
-    (fun dependant _locs ->
-      let dependant =
-        Fpath.normalize @@ Fpath.( // ) (Fpath.parent file) dependant
-      in
-      add dependant file)
-    new_unit.Slipshow.Ast.deps
+  update_state ~new_deps file
 
 let get_roots u =
   let rec get_roots visited u =

--- a/src/lspishow/rev_deps.ml
+++ b/src/lspishow/rev_deps.ml
@@ -5,6 +5,9 @@ let hashtbl_update h key f =
 
 type t = (Fpath.t, Fpath.Set.t) Hashtbl.t
 
+let as_map (v : t) : Fpath.set Fpath.Map.t =
+  v |> Hashtbl.to_seq |> Fpath.Map.of_seq
+
 let current : t = Hashtbl.create 10
 
 let remove dependant depends =

--- a/src/lspishow/rev_deps.ml
+++ b/src/lspishow/rev_deps.ml
@@ -3,36 +3,50 @@ let hashtbl_update h key f =
   | None -> ()
   | Some v -> Hashtbl.replace h key v
 
-type t = (Fpath.t, Fpath.Set.t) Hashtbl.t
+type t = {
+  rev_deps : (Fpath.t, Fpath.Set.t) Hashtbl.t;
+  deps : (Fpath.t, Fpath.Set.t) Hashtbl.t;
+      (** We are only interested in the rev deps but we store the deps to know
+          how to update when the deps change *)
+}
 
 let as_map (v : t) : Fpath.set Fpath.Map.t =
-  v |> Hashtbl.to_seq |> Fpath.Map.of_seq
+  v.rev_deps |> Hashtbl.to_seq |> Fpath.Map.of_seq
 
-let current : t = Hashtbl.create 10
+let current : t = { rev_deps = Hashtbl.create 10; deps = Hashtbl.create 10 }
 
 let remove dependant depends =
-  hashtbl_update current dependant @@ Option.map (Fpath.Set.remove depends)
+  hashtbl_update current.rev_deps dependant
+  @@ Option.map (Fpath.Set.remove depends)
 
 let add dependant depends =
-  hashtbl_update current dependant @@ function
+  hashtbl_update current.rev_deps dependant @@ function
   | None -> Some (Fpath.Set.singleton depends)
   | Some set -> Some (Fpath.Set.add depends set)
 
 let get dependant =
-  Hashtbl.find_opt current dependant |> Option.value ~default:Fpath.Set.empty
+  Hashtbl.find_opt current.rev_deps dependant
+  |> Option.value ~default:Fpath.Set.empty
 
-let update_state ~old_unit ~new_unit file =
+let update_state ~new_unit file =
   let () =
-    match old_unit with
+    match Hashtbl.find_opt current.deps file with
     | None -> ()
-    | Some { Slipshow.Ast.deps; _ } ->
-        Fpath.Map.iter
-          (fun dependant _locs ->
+    | Some deps ->
+        Fpath.Set.iter
+          (fun dependant ->
             let dependant =
               Fpath.normalize @@ Fpath.( // ) (Fpath.parent file) dependant
             in
             remove dependant file)
           deps
+  in
+  let () =
+    let new_deps =
+      new_unit.Slipshow.Ast.deps |> Fpath.Map.to_seq |> Seq.map fst
+      |> Fpath.Set.of_seq
+    in
+    Hashtbl.replace current.deps file new_deps
   in
   Fpath.Map.iter
     (fun dependant _locs ->

--- a/src/lspishow/rev_deps.mli
+++ b/src/lspishow/rev_deps.mli
@@ -3,15 +3,10 @@ type t
 val as_map : t -> Fpath.set Fpath.Map.t
 
 val current : t
-(** Rev deps for opened buffers. **)
+(** Rev deps for opened buffers. *)
 
-val update_state :
-  old_unit:Slipshow.Ast.unit' option ->
-  new_unit:Slipshow.Ast.unit' ->
-  Fpath.t ->
-  unit
-(** Updates the rev deps of a changed units. Needs the old value to remove
-    recorded deps. **)
+val update_state : new_unit:Slipshow.Ast.unit' -> Fpath.t -> unit
+(** Updates the rev deps of a changed units. *)
 
 val get_roots : Fpath.t -> Fpath.set
-(** Get the root(s) of a path. **)
+(** Get the root(s) of a path. *)

--- a/src/lspishow/rev_deps.mli
+++ b/src/lspishow/rev_deps.mli
@@ -1,4 +1,6 @@
-type t = (Fpath.t, Fpath.set) Hashtbl.t
+type t
+
+val as_map : t -> Fpath.set Fpath.Map.t
 
 val current : t
 (** Rev deps for opened buffers. **)

--- a/src/lspishow/rev_deps.mli
+++ b/src/lspishow/rev_deps.mli
@@ -8,5 +8,7 @@ val current : t
 val update_state : new_unit:Slipshow.Ast.unit' -> Fpath.t -> unit
 (** Updates the rev deps of a changed units. *)
 
+val remove : Fpath.t -> unit
+
 val get_roots : Fpath.t -> Fpath.set
 (** Get the root(s) of a path. *)


### PR DESCRIPTION
Register for the capability, to receive notifications for all file system change. Then, update all roots that depend on the watched file.

Could be better to only register for the dependencies, and update that when the dependencies change. Let's experiment with the simpler setup first.