### PR TITLE
Don't spam notif about the start of the lsp server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 - Drawings are now saved through the preview server (#249, #254)
 - Drawings are anchored to the point where the drawing has been added. (#262)
+- Don't spam with notifications to tell about the URL of the slipshow server
+  (#265)
 
 ### Fixed
 

--- a/src/lspishow/lsp_preview.ml
+++ b/src/lspishow/lsp_preview.ml
@@ -30,8 +30,11 @@ let initialize ~notify_back () =
   let port0 = 8080 in
   let rec loop port =
     server_port := Some port;
-    let* () =
-      send_info ~notify_back "Starting preview server on port %d" port
+    let to_cancel =
+      let* () = Lwt_unix.sleep 1.0 in
+      if !server_port = Some port then
+        send_info ~notify_back "Starting preview server on port %d" port
+      else send_info ~notify_back "Port %d appears already used" port
     in
     let* try_port =
       Slipshow_server.Server.do_serve ~port (roots_state, roots_list)
@@ -39,8 +42,8 @@ let initialize ~notify_back () =
     match try_port with
     | Ok () -> Lwt.return_unit
     | Error `Addr_in_use ->
-        let* () = send_info ~notify_back "Port %d appears already used" port in
         let port = port + 1 in
+        Lwt.cancel to_cancel;
         if port - port0 > 100 then (
           server_port := None;
           let* () =


### PR DESCRIPTION
VScode does not show more than three, which confused me. You then have a "notification center" that you can open by clicking on the bell on bottom right, ad it has a dot on it if you have not shown notifications.

Still, I prefered to cancel the promise, hiding the "Port %d appears already used" since it's better to have few notifications.